### PR TITLE
RMRK mint with metadata

### DIFF
--- a/contracts/rmrk/lib.rs
+++ b/contracts/rmrk/lib.rs
@@ -316,21 +316,18 @@ pub mod rmrk_contract {
             // only owner is allowed to mint
             set_sender(accounts.bob);
             assert_eq!(
-                rmrk.mint_rmrk(RMRK_METADATA.into()),
+                rmrk.mint_rmrk(RMRK_METADATA.into(), accounts.bob),
                 Err(PSP34Error::Custom(String::from("O::CallerIsNotOwner")))
             );
 
             // owner mints
             set_sender(accounts.alice);
             assert_eq!(rmrk.total_supply(), 0);
-            assert!(rmrk.mint_rmrk(RMRK_METADATA.into()).is_ok());
+            assert!(rmrk.mint_rmrk(RMRK_METADATA.into(), accounts.bob).is_ok());
             assert_eq!(rmrk.total_supply(), 1);
-            assert_eq!(rmrk.owner_of(Id::U64(1)), Some(accounts.alice));
-            assert_eq!(rmrk.balance_of(accounts.alice), 1);
-            assert_eq!(
-                rmrk.owners_token_by_index(accounts.alice, 0),
-                Ok(Id::U64(1))
-            );
+            assert_eq!(rmrk.owner_of(Id::U64(1)), Some(accounts.bob));
+            assert_eq!(rmrk.balance_of(accounts.bob), 1);
+            assert_eq!(rmrk.owners_token_by_index(accounts.bob, 0), Ok(Id::U64(1)));
             assert_eq!(1, ink_env::test::recorded_events().count());
 
             // token_uri for rmrk mint works

--- a/logics/impls/rmrk/types.rs
+++ b/logics/impls/rmrk/types.rs
@@ -6,6 +6,7 @@ use openbrush::{
     traits::{
         AccountId,
         Balance,
+        String,
     },
 };
 
@@ -40,4 +41,5 @@ pub struct Psp34CustomData {
     pub collection_id: u32,
     pub max_supply: u64,
     pub price_per_mint: Balance,
+    pub nft_metadata: Mapping<Id, String>,
 }

--- a/logics/traits/psp34_custom.rs
+++ b/logics/traits/psp34_custom.rs
@@ -34,6 +34,10 @@ pub trait Psp34Custom {
     #[ink(message, payable)]
     fn mint_next(&mut self) -> Result<(), PSP34Error>;
 
+    /// Mint next available token with specific metadata
+    #[ink(message)]
+    fn mint_rmrk(&mut self, metadata: PreludeString, to: AccountId) -> Result<(), PSP34Error>;
+
     /// Mint one or more tokens.
     #[ink(message, payable)]
     fn mint_for(&mut self, to: AccountId, mint_amount: u64) -> Result<(), PSP34Error>;


### PR DESCRIPTION
allow owner to mint NFT with metadata as an argument.
This is due to compatibility with existing RMRK implementations 
