### PR TITLE
Unify `ensure_exists`

### DIFF
--- a/logics/impls/rmrk/multiasset.rs
+++ b/logics/impls/rmrk/multiasset.rs
@@ -4,10 +4,13 @@ use crate::impls::rmrk::{
     errors::RmrkError,
     types::*,
 };
-pub use crate::traits::multiasset::{
-    Internal,
-    MultiAsset,
-    MultiAssetEvents,
+pub use crate::traits::{
+    multiasset::{
+        Internal,
+        MultiAsset,
+        MultiAssetEvents,
+    },
+    utils,
 };
 use ink_prelude::vec::Vec;
 use openbrush::{
@@ -42,15 +45,6 @@ where
         }
 
         None
-    }
-
-    /// Check if token is minted. Return the owner
-    default fn ensure_exists(&self, id: &Id) -> Result<AccountId, PSP34Error> {
-        let token_owner = self
-            .data::<psp34::Data<enumerable::Balances>>()
-            .owner_of(id.clone())
-            .ok_or(PSP34Error::TokenNotExists)?;
-        Ok(token_owner)
     }
 
     /// Ensure that the caller is the token owner
@@ -206,7 +200,8 @@ impl<T> MultiAsset for T
 where
     T: Storage<MultiAssetData>
         + Storage<psp34::Data<enumerable::Balances>>
-        + Storage<ownable::Data>,
+        + Storage<ownable::Data>
+        + utils::Internal,
 {
     /// Used to add a asset entry.
     #[modifiers(only_owner)]

--- a/logics/impls/rmrk/nesting.rs
+++ b/logics/impls/rmrk/nesting.rs
@@ -1,14 +1,18 @@
 //! This module enables nesting of RMRK or any other NFT which inherits PSP34.
 
-use crate::impls::rmrk::{
-    errors::RmrkError,
-    types::*,
-};
 pub use crate::traits::nesting::{
     Internal,
     Nesting,
     NestingEvents,
 };
+use crate::{
+    impls::rmrk::{
+        errors::RmrkError,
+        types::*,
+    },
+    traits,
+};
+
 use ink_env::CallFlags;
 use ink_prelude::vec::Vec;
 use openbrush::{
@@ -155,15 +159,6 @@ where
         Ok(())
     }
 
-    /// Check if token is minted. Return the owner
-    default fn ensure_exists(&self, id: &Id) -> Result<AccountId, PSP34Error> {
-        let token_owner = self
-            .data::<psp34::Data<enumerable::Balances>>()
-            .owner_of(id.clone())
-            .ok_or(PSP34Error::TokenNotExists)?;
-        Ok(token_owner)
-    }
-
     /// Check if caller is the owner of this parent token
     default fn is_caller_parent_owner(
         &self,
@@ -205,7 +200,7 @@ where
 
 impl<T> Nesting for T
 where
-    T: Storage<NestingData> + Storage<psp34::Data<enumerable::Balances>>,
+    T: Storage<NestingData> + Storage<psp34::Data<enumerable::Balances>> + traits::utils::Internal,
 {
     /// Add a child NFT (from different collection) to the NFT in this collection
     /// The status of the added child is `Pending` if caller is not owner of child NFT

--- a/logics/impls/rmrk/utils.rs
+++ b/logics/impls/rmrk/utils.rs
@@ -24,6 +24,7 @@ use openbrush::{
     },
     modifiers,
     traits::{
+        AccountId,
         Balance,
         Storage,
         String,
@@ -53,7 +54,7 @@ where
 
     /// Get URI for the token Id
     default fn token_uri(&self, token_id: u64) -> Result<PreludeString, PSP34Error> {
-        self._token_exists(Id::U64(token_id))?;
+        self.ensure_exists(&Id::U64(token_id))?;
         let value = self.get_attribute(
             self.data::<psp34::Data<enumerable::Balances>>()
                 .collection_id(),
@@ -91,14 +92,15 @@ where
 /// Helper trait for Psp34Custom
 impl<T> Internal for T
 where
-    T: Storage<MintingData> + Storage<psp34::Data<enumerable::Balances>>,
+    T: Storage<psp34::Data<enumerable::Balances>>,
 {
     /// Check if token is minted
-    default fn _token_exists(&self, id: Id) -> Result<(), PSP34Error> {
-        self.data::<psp34::Data<enumerable::Balances>>()
-            .owner_of(id)
+    default fn ensure_exists(&self, id: &Id) -> Result<AccountId, PSP34Error> {
+        let account_id = self
+            .data::<psp34::Data<enumerable::Balances>>()
+            .owner_of(id.clone())
             .ok_or(PSP34Error::TokenNotExists)?;
-        Ok(())
+        Ok(account_id)
     }
 }
 

--- a/logics/traits/multiasset.rs
+++ b/logics/traits/multiasset.rs
@@ -122,9 +122,6 @@ pub trait Internal {
     /// Check if asset is already added.
     fn asset_id_exists(&self, asset_id: AssetId) -> Option<String>;
 
-    /// TODO duplicated. find common module for this method
-    fn ensure_exists(&self, id: &Id) -> Result<AccountId, PSP34Error>;
-
     /// Ensure that the caller is the token owner
     fn ensure_token_owner(&self, token_owner: AccountId) -> Result<(), PSP34Error>;
 

--- a/logics/traits/nesting.rs
+++ b/logics/traits/nesting.rs
@@ -171,9 +171,6 @@ pub trait Internal {
         child_nft: &ChildNft,
     ) -> Result<(), PSP34Error>;
 
-    /// Check if token is minted. Return the owner.
-    fn ensure_exists(&self, id: &Id) -> Result<AccountId, PSP34Error>;
-
     /// Check if caller is the owner of this parent token.
     fn is_caller_parent_owner(
         &self,

--- a/logics/traits/utils.rs
+++ b/logics/traits/utils.rs
@@ -6,13 +6,16 @@ use openbrush::{
         Id,
         PSP34Error,
     },
-    traits::Balance,
+    traits::{
+        AccountId,
+        Balance,
+    },
 };
 
 /// Trait definitions for Utils internal functions.
 pub trait Internal {
     /// Check if token is minted.
-    fn _token_exists(&self, id: Id) -> Result<(), PSP34Error>;
+    fn ensure_exists(&self, id: &Id) -> Result<AccountId, PSP34Error>;
 }
 
 /// Trait definitions for Utils functions


### PR DESCRIPTION
[Reference issue](https://github.com/rmrk-team/rmrk-ink/issues/16)

This combines existing implementations of `ensure_exists | _token_exists`, however breaks convention by exposing `util::Internal` to top level data storage implementations.

Currently `util::Util` is not generic and has a dependency of `Storage<MintingData>`, which is why the `Internal` trait has to be used. 

One solution is to make Util generic by removing any rmrk-storage dependencies, allowing `MultiAssetData` & `Nesting` to use util::Util directly. Alternatively we leave Util as being bound to `MintingData`, and create a new trait (perhaps Common?) for data agnostic behaviour.
