### PR TITLE
Refactor/error handling

### DIFF
--- a/crates/base/src/internal.rs
+++ b/crates/base/src/internal.rs
@@ -1,39 +1,32 @@
 use crate::BaseData;
 
 use rmrk_common::{
-    errors::RmrkError,
+    errors::{
+        Result,
+        RmrkError,
+    },
     types::*,
 };
 
-use openbrush::{
-    contracts::psp34::extensions::enumerable::*,
-    traits::{
-        Storage,
-        String,
-    },
-};
+use openbrush::traits::Storage;
 
 /// Implement internal helper trait for Base
 pub trait Internal {
-    fn ensure_only_slot(&self, part_id: PartId) -> Result<Part, PSP34Error>;
+    fn ensure_only_slot(&self, part_id: PartId) -> Result<Part>;
 }
 /// Implement internal helper trait for Base
 impl<T> Internal for T
 where
     T: Storage<BaseData>,
 {
-    default fn ensure_only_slot(&self, part_id: PartId) -> Result<Part, PSP34Error> {
+    default fn ensure_only_slot(&self, part_id: PartId) -> Result<Part> {
         if let Some(part) = self.data::<BaseData>().parts.get(part_id) {
             if part.part_type != PartType::Slot {
-                return Err(PSP34Error::Custom(String::from(
-                    RmrkError::PartIsNotSlot.as_str(),
-                )))
+                return Err(RmrkError::PartIsNotSlot.into())
             }
             return Ok(part)
         } else {
-            return Err(PSP34Error::Custom(String::from(
-                RmrkError::UnknownPartId.as_str(),
-            )))
+            return Err(RmrkError::UnknownPartId.into())
         }
     }
 }

--- a/crates/base/src/traits.rs
+++ b/crates/base/src/traits.rs
@@ -1,17 +1,17 @@
 //! RMRK Base traits
 
-use rmrk_common::types::*;
+use rmrk_common::{
+    errors::Result,
+    types::*,
+};
 
 use ink_prelude::{
     string::String as PreludeString,
     vec::Vec,
 };
-use openbrush::{
-    contracts::psp34::PSP34Error,
-    traits::{
-        AccountId,
-        String,
-    },
+use openbrush::traits::{
+    AccountId,
+    String,
 };
 
 #[openbrush::wrapper]
@@ -22,7 +22,7 @@ pub type BaseRef = dyn Base;
 pub trait Base {
     /// Add one or more parts to the base
     #[ink(message)]
-    fn add_part_list(&mut self, parts: Vec<Part>) -> Result<(), PSP34Error>;
+    fn add_part_list(&mut self, parts: Vec<Part>) -> Result<()>;
 
     /// Add collection address(es) that can be used to equip given `PartId`.
     #[ink(message)]
@@ -30,19 +30,19 @@ pub trait Base {
         &mut self,
         part_id: PartId,
         equippable_address: Vec<AccountId>,
-    ) -> Result<(), PSP34Error>;
+    ) -> Result<()>;
 
     /// Remove list of equippable addresses for given Part
     #[ink(message)]
-    fn reset_equippable_addresses(&mut self, part_id: PartId) -> Result<(), PSP34Error>;
+    fn reset_equippable_addresses(&mut self, part_id: PartId) -> Result<()>;
 
     /// Sets the is_equippable_by_all flag to true, meaning that any collection may be equipped into the `PartId`
     #[ink(message)]
-    fn set_equippable_by_all(&mut self, part_id: PartId) -> Result<(), PSP34Error>;
+    fn set_equippable_by_all(&mut self, part_id: PartId) -> Result<()>;
 
     //// Set the Base metadataURI.
     #[ink(message)]
-    fn setup_base(&mut self, base_metadata: String) -> Result<(), PSP34Error>;
+    fn setup_base(&mut self, base_metadata: String) -> Result<()>;
 
     //// Get the Base metadataURI.
     #[ink(message)]
@@ -58,11 +58,7 @@ pub trait Base {
 
     /// Check whether the given address is allowed to equip the desired `PartId`.
     #[ink(message)]
-    fn ensure_equippable(
-        &self,
-        part_id: PartId,
-        target_address: AccountId,
-    ) -> Result<(), PSP34Error>;
+    fn ensure_equippable(&self, part_id: PartId, target_address: AccountId) -> Result<()>;
 
     /// Checks if the given `PartId` can be equipped by any collection
     #[ink(message)]

--- a/crates/common/src/errors.rs
+++ b/crates/common/src/errors.rs
@@ -1,6 +1,46 @@
 //! Error definition for RMRK contract
 
-use openbrush::traits::String;
+use ink_prelude::string::ToString;
+use openbrush::contracts::{
+    ownable::OwnableError,
+    psp34::PSP34Error,
+    reentrancy_guard::ReentrancyGuardError,
+};
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, PartialEq, Eq, scale::Encode, scale::Decode)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub enum Error {
+    Rmrk(RmrkError),
+    PSP34(PSP34Error),
+    Ownable(OwnableError),
+    Reentrancy(ReentrancyGuardError),
+}
+
+impl From<RmrkError> for Error {
+    fn from(err: RmrkError) -> Self {
+        Self::Rmrk(err)
+    }
+}
+
+impl From<PSP34Error> for Error {
+    fn from(err: PSP34Error) -> Self {
+        Self::PSP34(err)
+    }
+}
+
+impl From<OwnableError> for Error {
+    fn from(err: OwnableError) -> Self {
+        Self::Ownable(err)
+    }
+}
+
+impl From<ReentrancyGuardError> for Error {
+    fn from(err: ReentrancyGuardError) -> Self {
+        Self::Reentrancy(err)
+    }
+}
 
 #[derive(Debug, PartialEq, Eq, scale::Encode, scale::Decode)]
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
@@ -34,8 +74,8 @@ pub enum RmrkError {
     WithdrawalFailed,
 }
 
-impl RmrkError {
-    pub fn as_str(&self) -> String {
+impl ToString for RmrkError {
+    fn to_string(&self) -> String {
         match self {
             RmrkError::AcceptedAssetsMissing => String::from("AcceptedAssetsMissing"),
             RmrkError::AddingPendingAsset => String::from("AddingPendingAsset"),

--- a/crates/equippable/src/lib.rs
+++ b/crates/equippable/src/lib.rs
@@ -13,7 +13,10 @@ use rmrk_base::{
 };
 
 use rmrk_common::{
-    errors::RmrkError,
+    errors::{
+        Result,
+        RmrkError,
+    },
     types::*,
     utils::Utils,
 };
@@ -72,7 +75,7 @@ where
         slot_part_id: PartId,
         child_nft: ChildNft,
         child_asset_id: AssetId,
-    ) -> Result<(), PSP34Error> {
+    ) -> Result<()> {
         let token_owner = self.ensure_exists_and_get_owner(&token_id)?;
         self.ensure_token_owner(token_owner)?;
         self.ensure_asset_accepts_slot(&asset_id, &slot_part_id)?;
@@ -102,7 +105,7 @@ where
     }
 
     /// Used to unequip child from parent token.
-    default fn unequip(&mut self, token_id: Id, slot_part_id: PartId) -> Result<(), PSP34Error> {
+    default fn unequip(&mut self, token_id: Id, slot_part_id: PartId) -> Result<()> {
         let token_owner = self.ensure_exists_and_get_owner(&token_id)?;
         self.ensure_token_owner(token_owner)?;
         let equipment = self.ensure_equipped(&token_id, &slot_part_id)?;
@@ -122,7 +125,7 @@ where
         equippable_group_id: EquippableGroupId,
         parent_address: AccountId,
         part_id: PartId,
-    ) -> Result<(), PSP34Error> {
+    ) -> Result<()> {
         self.data::<EquippableData>()
             .valid_parent_slot
             .insert((equippable_group_id, parent_address), &part_id);
@@ -143,7 +146,7 @@ where
         &self,
         token_id: Id,
         asset_id: AssetId,
-    ) -> Result<Asset, PSP34Error> {
+    ) -> Result<Asset> {
         self.ensure_asset_accepted(&token_id, &asset_id)?;
 
         if let Some(asset) = self
@@ -153,9 +156,7 @@ where
         {
             return Ok(asset)
         } else {
-            return Err(PSP34Error::Custom(String::from(
-                RmrkError::AssetIdNotFound.as_str(),
-            )))
+            return Err(RmrkError::AssetIdNotFound.into())
         }
     }
 }

--- a/crates/equippable/src/traits.rs
+++ b/crates/equippable/src/traits.rs
@@ -1,5 +1,8 @@
 //! Trait definitions for Equippable module
-use rmrk_common::types::*;
+use rmrk_common::{
+    errors::Result,
+    types::*,
+};
 // use ink_prelude::vec::Vec;
 use openbrush::{
     contracts::psp34::{
@@ -37,7 +40,7 @@ pub trait Equippable {
         slot_part_id: PartId,
         child_nft: ChildNft,
         child_asset_id: AssetId,
-    ) -> Result<(), PSP34Error>;
+    ) -> Result<()>;
 
     /// Used to unequip child from parent token.
     /// # Requirements
@@ -52,7 +55,7 @@ pub trait Equippable {
     ///  * `child_asset_id` ID of the asset associated with the token we are unequipping
     /// Emits an {ChildAssetUnequipped} event.
     #[ink(message)]
-    fn unequip(&mut self, token_id: Id, slot_part_id: PartId) -> Result<(), PSP34Error>;
+    fn unequip(&mut self, token_id: Id, slot_part_id: PartId) -> Result<()>;
 
     /// Used to declare that the assets belonging to a given `equippableGroupId` are equippable into the `Slot`
     /// associated with the `partId` of the collection at the specified `parentAddress`
@@ -69,7 +72,7 @@ pub trait Equippable {
         equippable_group_id: EquippableGroupId,
         parent_address: AccountId,
         part_id: PartId,
-    ) -> Result<(), PSP34Error>;
+    ) -> Result<()>;
 
     /// Used to extend already added Asset with details needed to support equipping.
     /// These details are not present in MultiAsset trait to avoid dependencies on Equippable trait.
@@ -83,7 +86,7 @@ pub trait Equippable {
     //     asset_id: AssetId,
     //     group_id: EquippableGroupId,
     //     port_ids: Vec<PartId>,
-    // ) -> Result<(), PSP34Error>;
+    // ) -> Result<()>;
 
     /// Used to get the Equipment object equipped into the specified slot of the desired token.
     ///
@@ -101,11 +104,7 @@ pub trait Equippable {
     ///    * asset_id metadataURI,
     ///    * EquippableAsset
     #[ink(message)]
-    fn get_asset_and_equippable_data(
-        &self,
-        token_id: Id,
-        asset_id: AssetId,
-    ) -> Result<Asset, PSP34Error>;
+    fn get_asset_and_equippable_data(&self, token_id: Id, asset_id: AssetId) -> Result<Asset>;
 }
 
 /// Trait definitions for Resource ink events

--- a/crates/minting/src/internal.rs
+++ b/crates/minting/src/internal.rs
@@ -1,6 +1,9 @@
 use crate::MintingData;
 
-use rmrk_common::errors::RmrkError;
+use rmrk_common::errors::{
+    Result,
+    RmrkError,
+};
 
 use openbrush::{
     contracts::psp34::extensions::enumerable::*,
@@ -13,10 +16,10 @@ use openbrush::{
 /// Trait definitions for Minting internal functions.
 pub trait Internal {
     /// Check if the transferred mint values is as expected.
-    fn _check_value(&self, transfered_value: u128, mint_amount: u64) -> Result<(), PSP34Error>;
+    fn _check_value(&self, transfered_value: u128, mint_amount: u64) -> Result<()>;
 
     /// Check amount of tokens to be minted.
-    fn _check_amount(&self, mint_amount: u64) -> Result<(), PSP34Error>;
+    fn _check_amount(&self, mint_amount: u64) -> Result<()>;
 }
 
 /// Helper trait for Minting
@@ -25,11 +28,7 @@ where
     T: Storage<MintingData> + Storage<psp34::Data<enumerable::Balances>>,
 {
     /// Check if the transferred mint values is as expected
-    default fn _check_value(
-        &self,
-        transfered_value: u128,
-        mint_amount: u64,
-    ) -> Result<(), PSP34Error> {
+    default fn _check_value(&self, transfered_value: u128, mint_amount: u64) -> Result<()> {
         if let Some(value) =
             (mint_amount as u128).checked_mul(self.data::<MintingData>().price_per_mint)
         {
@@ -37,17 +36,13 @@ where
                 return Ok(())
             }
         }
-        return Err(PSP34Error::Custom(String::from(
-            RmrkError::BadMintValue.as_str(),
-        )))
+        return Err(RmrkError::BadMintValue.into())
     }
 
     /// Check amount of tokens to be minted
-    default fn _check_amount(&self, mint_amount: u64) -> Result<(), PSP34Error> {
+    default fn _check_amount(&self, mint_amount: u64) -> Result<()> {
         if mint_amount == 0 {
-            return Err(PSP34Error::Custom(String::from(
-                RmrkError::CannotMintZeroTokens.as_str(),
-            )))
+            return Err(RmrkError::CannotMintZeroTokens.into())
         }
         if let Some(amount) = self
             .data::<MintingData>()
@@ -58,8 +53,6 @@ where
                 return Ok(())
             }
         }
-        return Err(PSP34Error::Custom(String::from(
-            RmrkError::CollectionIsFull.as_str(),
-        )))
+        return Err(RmrkError::CollectionIsFull.into())
     }
 }

--- a/crates/minting/src/traits.rs
+++ b/crates/minting/src/traits.rs
@@ -1,12 +1,11 @@
 //! RMRK minting traits
 
+use rmrk_common::errors::Result;
+
 use ink_prelude::string::String as PreludeString;
-use openbrush::{
-    contracts::psp34::PSP34Error,
-    traits::{
-        AccountId,
-        Balance,
-    },
+use openbrush::traits::{
+    AccountId,
+    Balance,
 };
 
 #[openbrush::wrapper]
@@ -17,19 +16,15 @@ pub type MintingRef = dyn Minting;
 pub trait Minting {
     /// Mint next available token for the caller.
     #[ink(message, payable)]
-    fn mint_next(&mut self) -> Result<(), PSP34Error>;
+    fn mint_next(&mut self) -> Result<()>;
 
     /// Mint one or more tokens.
     #[ink(message, payable)]
-    fn mint(&mut self, to: AccountId, mint_amount: u64) -> Result<(), PSP34Error>;
+    fn mint(&mut self, to: AccountId, mint_amount: u64) -> Result<()>;
 
     /// Mint next available token with specific metadata
     #[ink(message)]
-    fn mint_with_metadata(
-        &mut self,
-        metadata: PreludeString,
-        to: AccountId,
-    ) -> Result<(), PSP34Error>;
+    fn mint_with_metadata(&mut self, metadata: PreludeString, to: AccountId) -> Result<()>;
 
     /// Get max supply of tokens.
     #[ink(message)]
@@ -41,5 +36,5 @@ pub trait Minting {
 
     /// Get URI for the token Id.
     #[ink(message)]
-    fn token_uri(&self, token_id: u64) -> Result<PreludeString, PSP34Error>;
+    fn token_uri(&self, token_id: u64) -> Result<PreludeString>;
 }

--- a/crates/minting/tests/main.rs
+++ b/crates/minting/tests/main.rs
@@ -73,13 +73,13 @@ pub mod rmrk_contract_minting {
             // check case when last_token_id.add(mint_amount) if more than u64::MAX
             assert_eq!(
                 rmrk._check_amount(3),
-                Err(PSP34Error::Custom(RmrkError::CollectionIsFull.as_str()))
+                Err(RmrkError::CollectionIsFull.into())
             );
 
             // check case when mint_amount is 0
             assert_eq!(
                 rmrk._check_amount(0),
-                Err(PSP34Error::Custom(RmrkError::CannotMintZeroTokens.as_str()))
+                Err(RmrkError::CannotMintZeroTokens.into())
             );
         }
 
@@ -90,7 +90,7 @@ pub mod rmrk_contract_minting {
             let mint_amount = u64::MAX;
             assert_eq!(
                 rmrk._check_value(transferred_value, mint_amount),
-                Err(PSP34Error::Custom(RmrkError::BadMintValue.as_str()))
+                Err(RmrkError::BadMintValue.into())
             );
         }
     }

--- a/crates/multiasset/src/traits.rs
+++ b/crates/multiasset/src/traits.rs
@@ -1,5 +1,8 @@
 //! Trait definitions for MultiAsset module
-use rmrk_common::types::*;
+use rmrk_common::{
+    errors::Result,
+    types::*,
+};
 
 use ink_prelude::vec::Vec;
 use openbrush::{
@@ -28,7 +31,7 @@ pub trait MultiAsset {
         equippable_group_id: EquippableGroupId,
         asset_uri: String,
         part_ids: Vec<PartId>,
-    ) -> Result<(), PSP34Error>;
+    ) -> Result<()>;
 
     /// Used to add an asset to a token.
     /// If the given asset is already added to the token, the execution will be reverted.
@@ -49,7 +52,7 @@ pub trait MultiAsset {
         token_id: Id,
         asset_id: AssetId,
         replaces_asset_with_id: Option<AssetId>,
-    ) -> Result<(), PSP34Error>;
+    ) -> Result<()>;
 
     /// Accepts an asset at from the pending array of given token.
     /// Migrates the asset from the token's pending asset array to the token's active asset array.
@@ -63,7 +66,7 @@ pub trait MultiAsset {
     ///  * assetId ID of the asset expected to be in the pending_asset list.
     /// Emits an {AssetAccepted} event.
     #[ink(message)]
-    fn accept_asset(&mut self, token_id: Id, asset_id: AssetId) -> Result<(), PSP34Error>;
+    fn accept_asset(&mut self, token_id: Id, asset_id: AssetId) -> Result<()>;
 
     /// Rejects an asset from the pending array of given token.
     /// Removes the asset from the token's pending asset array.
@@ -76,7 +79,7 @@ pub trait MultiAsset {
     ///  * assetId ID of the asset expected to be in the pending_asset list.
     /// Emits a {AssetRejected} event.
     #[ink(message)]
-    fn reject_asset(&mut self, token_id: Id, asset_id: AssetId) -> Result<(), PSP34Error>;
+    fn reject_asset(&mut self, token_id: Id, asset_id: AssetId) -> Result<()>;
 
     /// Used to specify the priorities for a given token's active assets.
     /// If the length of the priorities array doesn't match the length of the active assets array, the execution
@@ -88,7 +91,7 @@ pub trait MultiAsset {
     ///  * priorities Array of priorities for the assets
     /// Emits a {AssetPrioritySet} event.
     #[ink(message)]
-    fn set_priority(&mut self, token_id: Id, priorities: Vec<AssetId>) -> Result<(), PSP34Error>;
+    fn set_priority(&mut self, token_id: Id, priorities: Vec<AssetId>) -> Result<()>;
 
     /// Used to retrieve the total number of assets.
     /// # Returns
@@ -102,18 +105,18 @@ pub trait MultiAsset {
 
     /// Used to retrieve the total number of assets per token
     #[ink(message)]
-    fn total_token_assets(&self, token_id: Id) -> Result<(u64, u64), PSP34Error>;
+    fn total_token_assets(&self, token_id: Id) -> Result<(u64, u64)>;
 
     /// Fetch all accepted assets for the token_id
     #[ink(message)]
-    fn get_accepted_token_assets(&self, token_id: Id) -> Result<Option<Vec<AssetId>>, PSP34Error>;
+    fn get_accepted_token_assets(&self, token_id: Id) -> Result<Option<Vec<AssetId>>>;
 
     /// Remove the assets for the list of token assets
     #[ink(message)]
-    fn remove_asset(&mut self, token_id: Id, asset_id: AssetId) -> Result<(), PSP34Error>;
+    fn remove_asset(&mut self, token_id: Id, asset_id: AssetId) -> Result<()>;
 
     /// Check that asset id does not already exist.
-    fn ensure_asset_id_is_available(&self, asset_id: AssetId) -> Result<(), PSP34Error>;
+    fn ensure_asset_id_is_available(&self, asset_id: AssetId) -> Result<()>;
 }
 
 /// Trait definitions for MultiAsset ink events

--- a/crates/nesting/src/lib.rs
+++ b/crates/nesting/src/lib.rs
@@ -7,6 +7,7 @@ pub mod internal;
 pub mod traits;
 
 use rmrk_common::{
+    errors::Result,
     types::*,
     utils::Utils,
 };
@@ -63,11 +64,7 @@ where
     /// Ownership of child NFT will be transferred to this contract (cross contract call)
     /// On success emitts `RmrkEvent::ChildAdded`
     /// On success emitts `RmrkEvent::ChildAccepted` - only if caller is already owner of child NFT
-    default fn add_child(
-        &mut self,
-        to_parent_token_id: Id,
-        child_nft: ChildNft,
-    ) -> Result<(), PSP34Error> {
+    default fn add_child(&mut self, to_parent_token_id: Id, child_nft: ChildNft) -> Result<()> {
         let parent_owner = self.ensure_exists_and_get_owner(&to_parent_token_id)?;
         self.accepted(&to_parent_token_id, &child_nft)?;
         self.pending(&to_parent_token_id, &child_nft)?;
@@ -102,11 +99,7 @@ where
     /// # Result:
     /// Ownership of child NFT will be transferred to parent NFT owner (cross contract call)
     /// On success emitts `RmrkEvent::ChildRemoved`
-    default fn remove_child(
-        &mut self,
-        parent_token_id: Id,
-        child_nft: ChildNft,
-    ) -> Result<(), PSP34Error> {
+    default fn remove_child(&mut self, parent_token_id: Id, child_nft: ChildNft) -> Result<()> {
         self.ensure_exists_and_get_owner(&parent_token_id)?;
         let caller = Self::env().caller();
         self.is_caller_parent_owner(caller, &parent_token_id)?;
@@ -134,11 +127,7 @@ where
     /// # Result:
     /// Child Nft is moved from pending to accepted
     /// On success emitts `RmrkEvent::ChildAccepted`
-    default fn accept_child(
-        &mut self,
-        parent_token_id: Id,
-        child_nft: ChildNft,
-    ) -> Result<(), PSP34Error> {
+    default fn accept_child(&mut self, parent_token_id: Id, child_nft: ChildNft) -> Result<()> {
         self.ensure_exists_and_get_owner(&parent_token_id)?;
         let caller = Self::env().caller();
         self.is_caller_parent_owner(caller, &parent_token_id)?;
@@ -162,11 +151,7 @@ where
     /// # Result:
     /// Child Nft is removed from pending
     /// On success emitts `RmrkEvent::ChildRejected`
-    default fn reject_child(
-        &mut self,
-        parent_token_id: Id,
-        child_nft: ChildNft,
-    ) -> Result<(), PSP34Error> {
+    default fn reject_child(&mut self, parent_token_id: Id, child_nft: ChildNft) -> Result<()> {
         self.ensure_exists_and_get_owner(&parent_token_id)?;
         let caller = Self::env().caller();
         self.is_caller_parent_owner(caller, &parent_token_id)?;
@@ -197,7 +182,7 @@ where
         current_parent: Id,
         new_parent: Id,
         child_nft: ChildNft,
-    ) -> Result<(), PSP34Error> {
+    ) -> Result<()> {
         let current_parent_owner = self.ensure_exists_and_get_owner(&current_parent)?;
         let new_parent_owner = self.ensure_exists_and_get_owner(&new_parent)?;
         self.remove_accepted(&current_parent, &child_nft)?;
@@ -218,7 +203,7 @@ where
     ///
     /// # Result:
     /// Returns the tupple of `(accepted_children, pending_children)` count
-    fn children_balance(&self, parent_token_id: Id) -> Result<(u64, u64), PSP34Error> {
+    fn children_balance(&self, parent_token_id: Id) -> Result<(u64, u64)> {
         self.ensure_exists_and_get_owner(&parent_token_id)?;
         let parents_with_accepted_children = match self
             .data::<NestingData>()

--- a/crates/nesting/src/traits.rs
+++ b/crates/nesting/src/traits.rs
@@ -1,5 +1,8 @@
 //! Trait definitions for Nesting module
-use rmrk_common::types::*;
+use rmrk_common::{
+    errors::Result,
+    types::*,
+};
 
 use openbrush::{
     contracts::psp34::{
@@ -37,7 +40,7 @@ pub trait Nesting {
     /// On success emitts `RmrkEvent::ChildAdded`
     /// On success emitts `RmrkEvent::ChildAccepted` - only if caller is already owner of child NFT
     #[ink(message)]
-    fn add_child(&mut self, parent_token_id: Id, child_nft: ChildNft) -> Result<(), PSP34Error>;
+    fn add_child(&mut self, parent_token_id: Id, child_nft: ChildNft) -> Result<()>;
 
     /// Remove a child NFT (from different collection) from token_id in this collection.
     /// The status of added child is `Pending` if caller is not owner of child NFT
@@ -54,7 +57,7 @@ pub trait Nesting {
     /// Ownership of child NFT will be transferred to parent NFT owner (cross contract call)
     /// On success emitts `RmrkEvent::ChildRemoved`
     #[ink(message)]
-    fn remove_child(&mut self, parent_token_id: Id, child_nft: ChildNft) -> Result<(), PSP34Error>;
+    fn remove_child(&mut self, parent_token_id: Id, child_nft: ChildNft) -> Result<()>;
 
     /// Accept a child NFT (from different collection) to be owned by parent token.
     ///
@@ -69,7 +72,7 @@ pub trait Nesting {
     /// Child Nft is moved from pending to accepted
     /// On success emitts `RmrkEvent::ChildAccepted`
     #[ink(message)]
-    fn accept_child(&mut self, parent_token_id: Id, child_nft: ChildNft) -> Result<(), PSP34Error>;
+    fn accept_child(&mut self, parent_token_id: Id, child_nft: ChildNft) -> Result<()>;
 
     /// Reject a child NFT (from different collection).
     ///
@@ -84,7 +87,7 @@ pub trait Nesting {
     /// Child Nft is removed from pending
     /// On success emitts `RmrkEvent::ChildRejected`
     #[ink(message)]
-    fn reject_child(&mut self, parent_token_id: Id, child_nft: ChildNft) -> Result<(), PSP34Error>;
+    fn reject_child(&mut self, parent_token_id: Id, child_nft: ChildNft) -> Result<()>;
 
     /// Transfer the child NFT from one parent to another (in this collection).
     ///
@@ -101,7 +104,7 @@ pub trait Nesting {
     /// On success emitts `RmrkEvent::ChildAdded`
     /// On success emitts `RmrkEvent::ChildAccepted` - only if caller is already owner of child NFT
     #[ink(message)]
-    fn transfer_child(&mut self, from: Id, to: Id, child_nft: ChildNft) -> Result<(), PSP34Error>;
+    fn transfer_child(&mut self, from: Id, to: Id, child_nft: ChildNft) -> Result<()>;
 
     /// Read the number of children on the parent token.
     /// # Arguments:
@@ -110,7 +113,7 @@ pub trait Nesting {
     /// # Result:
     /// Returns the tupple of `(accepted_children, pending_children)` count
     #[ink(message)]
-    fn children_balance(&self, parent_token_id: Id) -> Result<(u64, u64), PSP34Error>;
+    fn children_balance(&self, parent_token_id: Id) -> Result<(u64, u64)>;
 }
 
 /// Trait definitions for Nesting ink events


### PR DESCRIPTION
Keep RMRK errors intact rather than downcasting to Strings and wrapping in `PSP34::Custom`.

- Clear distinction between true `PSP34` and `RMRK` errors
- Removes a lot of error boilerplate code
- Human readable logs in tests (Custom(String) prints as an encoded value)

@Maar-io made a good point about PSP34 potentially being a common interface between external contracts, so having our own error type produces are larger API surface area to cover.  One way to manage this is to also provide a `From<Error> for PSP34Error` to allow easy conversions if necessary. 
