### PR TITLE
Fix custom error types in JS tests

### DIFF
--- a/crates/base/src/lib.rs
+++ b/crates/base/src/lib.rs
@@ -26,7 +26,6 @@ use ink_storage::Mapping;
 use openbrush::{
     contracts::{
         ownable::*,
-        psp34::extensions::enumerable::*,
     },
     modifiers,
     traits::{

--- a/crates/equippable/src/internal.rs
+++ b/crates/equippable/src/internal.rs
@@ -25,7 +25,6 @@ use openbrush::{
     traits::{
         AccountId,
         Storage,
-        String,
     },
 };
 

--- a/crates/equippable/src/lib.rs
+++ b/crates/equippable/src/lib.rs
@@ -42,7 +42,6 @@ use openbrush::{
     traits::{
         AccountId,
         Storage,
-        String,
     },
 };
 

--- a/crates/equippable/src/traits.rs
+++ b/crates/equippable/src/traits.rs
@@ -7,7 +7,6 @@ use rmrk_common::{
 use openbrush::{
     contracts::psp34::{
         Id,
-        PSP34Error,
     },
     traits::AccountId,
 };

--- a/crates/minting/src/internal.rs
+++ b/crates/minting/src/internal.rs
@@ -9,7 +9,6 @@ use openbrush::{
     contracts::psp34::extensions::enumerable::*,
     traits::{
         Storage,
-        String,
     },
 };
 

--- a/crates/multiasset/src/internal.rs
+++ b/crates/multiasset/src/internal.rs
@@ -18,7 +18,6 @@ use openbrush::{
     contracts::psp34::extensions::enumerable::*,
     traits::{
         Storage,
-        String,
     },
 };
 

--- a/crates/multiasset/src/traits.rs
+++ b/crates/multiasset/src/traits.rs
@@ -8,7 +8,6 @@ use ink_prelude::vec::Vec;
 use openbrush::{
     contracts::psp34::{
         Id,
-        PSP34Error,
     },
     traits::String,
 };

--- a/crates/nesting/src/internal.rs
+++ b/crates/nesting/src/internal.rs
@@ -19,7 +19,6 @@ use openbrush::{
     traits::{
         AccountId,
         Storage,
-        String,
     },
 };
 

--- a/crates/nesting/src/traits.rs
+++ b/crates/nesting/src/traits.rs
@@ -7,7 +7,6 @@ use rmrk_common::{
 use openbrush::{
     contracts::psp34::{
         Id,
-        PSP34Error,
     },
     traits::AccountId,
 };

--- a/crates/rmrk/src/config.rs
+++ b/crates/rmrk/src/config.rs
@@ -1,4 +1,4 @@
-use rmrk_minting;
+
 
 use openbrush::{
     contracts::{

--- a/examples/equippable/lib.rs
+++ b/examples/equippable/lib.rs
@@ -442,8 +442,7 @@ pub mod rmrk_example_equippable {
         use openbrush::contracts::{
             ownable::OwnableError,
             psp34::PSP34Error,
-            reentrancy_guard::ReentrancyGuardError,
-        };
+         };
 
         use ink_lang as ink;
         use ink_prelude::string::String as PreludeString;

--- a/tests/base.spec.ts
+++ b/tests/base.spec.ts
@@ -4,11 +4,15 @@ import { encodeAddress } from "@polkadot/keyring";
 import BN from "bn.js";
 import Rmrk_factory from "../types/constructors/rmrk_example_equippable";
 import Rmrk from "../types/contracts/rmrk_example_equippable";
+import { RmrkError } from "../types/types-returns/rmrk_example_equippable";
 
 import { ApiPromise, WsProvider, Keyring } from "@polkadot/api";
 import { KeyringPair } from "@polkadot/keyring/types";
 import { ReturnNumber } from "@supercolony/typechain-types";
-import { PartType, Part } from "../types/types-arguments/rmrk_example_equippable";
+import {
+  PartType,
+  Part,
+} from "../types/types-arguments/rmrk_example_equippable";
 
 use(chaiAsPromised);
 
@@ -144,7 +148,7 @@ describe("RMRK Base tests", () => {
     const failAddEquip = await gem
       .withSigner(deployer)
       .query.addEquippableAddresses(1, [kanaria.address]);
-    expect(hex2a(failAddEquip.value.err.custom)).to.be.equal("PartIsNotSlot");
+    expect(failAddEquip.value.err.rmrk).to.be.equal(RmrkError.partIsNotSlot);
   });
 });
 

--- a/tests/nesting.spec.ts
+++ b/tests/nesting.spec.ts
@@ -4,6 +4,7 @@ import { encodeAddress } from "@polkadot/keyring";
 import BN from "bn.js";
 import Rmrk_factory from "../types/constructors/rmrk_example_equippable";
 import Rmrk from "../types/contracts/rmrk_example_equippable";
+import { RmrkError } from "../types/types-returns/rmrk_example_equippable";
 
 import { ApiPromise, WsProvider, Keyring } from "@polkadot/api";
 import { KeyringPair } from "@polkadot/keyring/types";
@@ -177,7 +178,8 @@ describe("RMRK Nesting tests", () => {
     const failResult = await parent
       .withSigner(dave)
       .query.acceptChild({ u64: 1 }, [child.address, { u64: 1 }]);
-    expect(hex2a(failResult.value.err.custom)).to.be.equal("NotTokenOwner");
+
+    expect(failResult.value.err.rmrk).to.be.equal(RmrkError.notTokenOwner);
 
     // bob accepts child
     const acceptChildGas = (
@@ -203,17 +205,16 @@ describe("RMRK Nesting tests", () => {
     const failAcceptResult = await parent
       .withSigner(bob)
       .query.acceptChild({ u64: 1 }, [child.address, { u64: 1 }]);
-    expect(hex2a(failAcceptResult.value.err.custom)).to.be.equal(
-      "AlreadyAddedChild"
+
+    expect(failAcceptResult.value.err.rmrk).to.be.equal(
+      RmrkError.alreadyAddedChild
     );
 
     // dave fails to remove child (not owner)
     const failRemoveChild = await parent
       .withSigner(dave)
       .query.removeChild({ u64: 1 }, [child.address, { u64: 1 }]);
-    expect(hex2a(failRemoveChild.value.err.custom)).to.be.equal(
-      "NotTokenOwner"
-    );
+    expect(failRemoveChild.value.err.rmrk).to.be.equal(RmrkError.notTokenOwner);
 
     // bob removes child
     const removeChildGas = (
@@ -307,16 +308,18 @@ describe("RMRK Nesting tests", () => {
     const failAcceptResult = await parent
       .withSigner(dave)
       .query.acceptChild({ u64: 1 }, [child.address, { u64: 1 }]);
-    expect(hex2a(failAcceptResult.value.err.custom)).to.be.equal(
-      "NotTokenOwner"
+
+    expect(failAcceptResult.value.err.rmrk).to.be.equal(
+      RmrkError.notTokenOwner
     );
 
     // since bob is owner of parent, dave fails to reject child
     const failRejectResult = await parent
       .withSigner(dave)
       .query.rejectChild({ u64: 1 }, [child.address, { u64: 1 }]);
-    expect(hex2a(failRejectResult.value.err.custom)).to.be.equal(
-      "NotTokenOwner"
+
+    expect(failRejectResult.value.err.rmrk).to.be.equal(
+      RmrkError.notTokenOwner
     );
 
     // bob rejects child

--- a/tests/psp34.spec.ts
+++ b/tests/psp34.spec.ts
@@ -4,6 +4,7 @@ import { encodeAddress } from "@polkadot/keyring";
 import BN from "bn.js";
 import Rmrk_factory from "../types/constructors/rmrk_example_equippable";
 import Rmrk from "../types/contracts/rmrk_example_equippable";
+import { RmrkError } from "../types/types-returns/rmrk_example_equippable";
 
 import { ApiPromise, WsProvider, Keyring } from "@polkadot/api";
 import { KeyringPair } from "@polkadot/keyring/types";
@@ -119,12 +120,10 @@ describe("Minting rmrk as psp34 tests", () => {
     ).to.equal(0);
 
     const { gasRequired } = await contract.withSigner(bob).query.mintNext();
-    await contract
-      .withSigner(bob)
-      .tx.mint(bob.address, 5, {
-        value: PRICE_PER_MINT.muln(5),
-        gasLimit: gasRequired * 2n,
-      });
+    await contract.withSigner(bob).tx.mint(bob.address, 5, {
+      value: PRICE_PER_MINT.muln(5),
+      gasLimit: gasRequired * 2n,
+    });
 
     expect(
       (await contract.query.totalSupply()).value.rawNumber.toNumber()
@@ -213,7 +212,8 @@ describe("Minting rmrk as psp34 tests", () => {
 
     // Bob trys to mint without funding
     let mintResult = await contract.withSigner(bob).query.mintNext();
-    expect(hex2a(mintResult.value.err.custom)).to.be.equal("BadMintValue");
+
+    expect(mintResult.value.err.rmrk).to.be.equal(RmrkError.badMintValue);
   });
 });
 


### PR DESCRIPTION
Update error types to generated enums instead of custom strings.