### PR TITLE
feature/query-helpers

### DIFF
--- a/crates/base/src/lib.rs
+++ b/crates/base/src/lib.rs
@@ -50,7 +50,7 @@ pub struct BaseData {
     pub next_part_id: PartId,
 
     /// Metadata for Base
-    pub base_metadata_uri: String,
+    pub base_uri: String,
 }
 
 impl<T> Base for T
@@ -114,14 +114,14 @@ where
     /// Sets the metadata URI for Base
     #[modifiers(only_role(CONTRIBUTOR))]
     default fn setup_base(&mut self, base_metadata: String) -> Result<()> {
-        self.data::<BaseData>().base_metadata_uri = base_metadata;
+        self.data::<BaseData>().base_uri = base_metadata;
 
         Ok(())
     }
 
     /// Get the Base metadataURI.
     default fn get_base_metadata(&self) -> PreludeString {
-        match PreludeString::from_utf8(self.data::<BaseData>().base_metadata_uri.clone()) {
+        match PreludeString::from_utf8(self.data::<BaseData>().base_uri.clone()) {
             Ok(m) => m,
             _ => PreludeString::from(""),
         }

--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -59,7 +59,7 @@ pub struct Part {
     pub equippable: Vec<AccountId>,
 
     /// Uri for this part
-    pub metadata_uri: String,
+    pub part_uri: String,
 
     /// Is accepting to be equipped by any collection
     pub is_equippable_by_all: bool,

--- a/crates/minting/src/lib.rs
+++ b/crates/minting/src/lib.rs
@@ -81,10 +81,11 @@ where
 
     /// Assign metadata to specified token.
     #[modifiers(only_role(CONTRIBUTOR))]
-    default fn assign_metadata(&mut self, token_id: Id, metadata: PreludeString) -> Result<()> {
+    default fn assign_metadata(&mut self, token_id: Id, metadata: String) -> Result<()> {
         self.data::<MintingData>()
             .nft_metadata
-            .insert(token_id, &String::from(metadata));
+            .insert(token_id, &metadata);
+
         return Ok(())
     }
 

--- a/crates/minting/src/traits.rs
+++ b/crates/minting/src/traits.rs
@@ -8,6 +8,7 @@ use openbrush::{
     traits::{
         AccountId,
         Balance,
+        String,
     },
 };
 
@@ -30,7 +31,7 @@ pub trait Minting {
 
     /// Assign metadata to specified token.
     #[ink(message)]
-    fn assign_metadata(&mut self, token_id: Id, metadata: PreludeString) -> Result<()>;
+    fn assign_metadata(&mut self, token_id: Id, metadata: String) -> Result<()>;
 
     /// Get max supply of tokens.
     #[ink(message)]

--- a/crates/minting/tests/core.rs
+++ b/crates/minting/tests/core.rs
@@ -284,7 +284,7 @@ pub mod rmrk_contract_minting {
             assert_eq!(rmrk.token_uri(1), Err(RmrkError::UriNotFound.into()));
 
             assert!(rmrk
-                .assign_metadata(Id::U64(1), PreludeString::from(RMRK_METADATA))
+                .assign_metadata(Id::U64(1), String::from(RMRK_METADATA))
                 .is_ok());
 
             assert_eq!(rmrk.token_uri(1), Ok(PreludeString::from(RMRK_METADATA)));

--- a/crates/multiasset/src/lib.rs
+++ b/crates/multiasset/src/lib.rs
@@ -230,20 +230,34 @@ where
 
     /// Used to retrieve asset's uri
     default fn get_asset_uri(&self, asset_id: AssetId) -> Option<String> {
-        if let Some(asset) = self
-            .data::<MultiAssetData>()
+        self.get_asset(asset_id).map(|asset| asset.asset_uri)
+    }
+
+    /// Used to retrieve asset
+    default fn get_asset(&self, asset_id: AssetId) -> Option<Asset> {
+        self.data::<MultiAssetData>()
             .collection_asset_entries
             .get(asset_id)
-        {
-            return Some(asset.asset_uri)
-        }
-        return None
     }
 
     /// Fetch all accepted assets for the token_id
-    fn get_accepted_token_assets(&self, token_id: Id) -> Result<Option<Vec<AssetId>>> {
+    fn get_accepted_token_assets(&self, token_id: Id) -> Result<Vec<AssetId>> {
         self.ensure_exists_and_get_owner(&token_id)?;
-        Ok(self.data::<MultiAssetData>().accepted_assets.get(&token_id))
+        Ok(self
+            .data::<MultiAssetData>()
+            .accepted_assets
+            .get(&token_id)
+            .unwrap_or_default())
+    }
+
+    /// Fetch all pending assets for the token_id
+    fn get_pending_token_assets(&self, token_id: Id) -> Result<Vec<AssetId>> {
+        self.ensure_exists_and_get_owner(&token_id)?;
+        Ok(self
+            .data::<MultiAssetData>()
+            .pending_assets
+            .get(&token_id)
+            .unwrap_or_default())
     }
 }
 

--- a/crates/multiasset/src/traits.rs
+++ b/crates/multiasset/src/traits.rs
@@ -100,13 +100,21 @@ pub trait MultiAsset {
     #[ink(message)]
     fn get_asset_uri(&self, asset_id: AssetId) -> Option<String>;
 
+    /// Used to retrieve asset
+    #[ink(message)]
+    fn get_asset(&self, asset_id: AssetId) -> Option<Asset>;
+
     /// Used to retrieve the total number of assets per token
     #[ink(message)]
     fn total_token_assets(&self, token_id: Id) -> Result<(u64, u64)>;
 
     /// Fetch all accepted assets for the token_id
     #[ink(message)]
-    fn get_accepted_token_assets(&self, token_id: Id) -> Result<Option<Vec<AssetId>>>;
+    fn get_accepted_token_assets(&self, token_id: Id) -> Result<Vec<AssetId>>;
+
+    /// Fetch all pending assets for the token_id
+    #[ink(message)]
+    fn get_pending_token_assets(&self, token_id: Id) -> Result<Vec<AssetId>>;
 
     /// Remove the assets for the list of token assets
     #[ink(message)]

--- a/crates/nesting/src/lib.rs
+++ b/crates/nesting/src/lib.rs
@@ -228,6 +228,22 @@ where
             parents_with_pending_children,
         ))
     }
+
+    /// Get all pending children for parent token_id
+    fn get_pending_children(&self, parent_token_id: Id) -> Vec<ChildNft> {
+        self.data::<NestingData>()
+            .pending_children
+            .get(&parent_token_id)
+            .unwrap_or_default()
+    }
+
+    /// Get all accepted children for parent token_id
+    fn get_accepted_children(&self, parent_token_id: Id) -> Vec<ChildNft> {
+        self.data::<NestingData>()
+            .accepted_children
+            .get(&parent_token_id)
+            .unwrap_or_default()
+    }
 }
 
 /// Event trait for Nesting

--- a/crates/nesting/src/traits.rs
+++ b/crates/nesting/src/traits.rs
@@ -4,6 +4,7 @@ use rmrk_common::{
     types::*,
 };
 
+use ink_prelude::vec::Vec;
 use openbrush::{
     contracts::psp34::Id,
     traits::AccountId,
@@ -111,6 +112,14 @@ pub trait Nesting {
     /// Returns the tupple of `(accepted_children, pending_children)` count
     #[ink(message)]
     fn children_balance(&self, parent_token_id: Id) -> Result<(u64, u64)>;
+
+    /// Get all pending children for parent token_id
+    #[ink(message)]
+    fn get_pending_children(&self, parent_token_id: Id) -> Vec<ChildNft>;
+
+    /// Get all accepted children for parent token_id
+    #[ink(message)]
+    fn get_accepted_children(&self, parent_token_id: Id) -> Vec<ChildNft>;
 }
 
 /// Trait definitions for Nesting ink events

--- a/crates/rmrk/Cargo.toml
+++ b/crates/rmrk/Cargo.toml
@@ -17,12 +17,12 @@ scale-info = { version = "2", default-features = false, features = ["derive"], o
 
 openbrush = { tag = "v2.3.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["access_control", "psp34", "reentrancy_guard"] }
 
-rmrk_base = { path = "../base", default-features = false, optional = true }
-rmrk_minting = { path = "../minting", default-features = false, optional = true }
-rmrk_multiasset = { path = "../multiasset", default-features = false, optional = true }
-rmrk_nesting = { path = "../nesting", default-features = false, optional = true }
-rmrk_common = { path = "../common", default-features = false, optional = true }
-rmrk_equippable = { path = "../equippable", default-features = false, optional = true }
+rmrk_base = { path = "../base", default-features = false }
+rmrk_minting = { path = "../minting", default-features = false }
+rmrk_multiasset = { path = "../multiasset", default-features = false }
+rmrk_nesting = { path = "../nesting", default-features = false }
+rmrk_common = { path = "../common", default-features = false }
+rmrk_equippable = { path = "../equippable", default-features = false }
 
 [lib]
 path = "src/lib.rs"
@@ -48,7 +48,5 @@ std = [
     "rmrk_nesting/std",
     "rmrk_equippable/std",
 ]
-mintable = [ "rmrk_common", "rmrk_minting" ] 
-equippable = ["mintable", "rmrk_base", "rmrk_multiasset", "rmrk_nesting", "rmrk_equippable"]
 
 

--- a/crates/rmrk/src/config.rs
+++ b/crates/rmrk/src/config.rs
@@ -1,6 +1,4 @@
-use rmrk_common::roles::CONTRIBUTOR;
-use rmrk_minting;
-
+use ink_prelude::vec::Vec;
 use openbrush::{
     contracts::{
         access_control::*,
@@ -19,94 +17,72 @@ use openbrush::{
     },
 };
 
-pub trait Config<T> {
-    fn config(
-        &mut self,
-        name: String,
-        symbol: String,
-        base_uri: String,
-        max_supply: u64,
-        price_per_mint: Balance,
-        collection_metadata: String,
-    );
+use rmrk_base::traits::Base;
+use rmrk_common::{
+    roles::CONTRIBUTOR,
+    types::*,
+};
+use rmrk_minting::{
+    self,
+    traits::MintingLazy,
+};
 
-    fn config_with_royalties(
-        &mut self,
-        name: String,
-        symbol: String,
-        base_uri: String,
-        max_supply: u64,
-        price_per_mint: Balance,
-        collection_metadata: String,
-        royalty_receiver: AccountId,
-        royalty: u8,
-    );
+pub fn with_collection<T>(
+    instance: &mut T,
+    name: String,
+    symbol: String,
+    base_uri: String,
+    metadata: String,
+    max_supply: u64,
+) where
+    T: Storage<rmrk_minting::MintingData>
+        + Storage<psp34::Data<enumerable::Balances>>
+        + Storage<metadata::Data>,
+{
+    let minting: &mut rmrk_minting::MintingData = <T as StorageAsMut>::data(instance);
+    minting.max_supply = max_supply;
+    let psp34: &psp34::Data<enumerable::Balances> = <T as StorageAsRef>::data(instance);
+    let collection_id = psp34.collection_id();
+    instance._set_attribute(collection_id.clone(), String::from("name"), name);
+    instance._set_attribute(collection_id.clone(), String::from("symbol"), symbol);
+    instance._set_attribute(collection_id.clone(), String::from("baseUri"), base_uri);
+    instance._set_attribute(collection_id, String::from("collection_metadata"), metadata);
 }
 
-impl<T> Config<T> for T
+pub fn with_lazy_mint<T>(instance: &mut T, price_per_mint: Balance)
 where
-    T: openbrush::traits::DefaultEnv
+    T: MintingLazy
         + Storage<rmrk_minting::MintingData>
-        + Storage<psp34::Data<enumerable::Balances>>
-        + Storage<access_control::Data>
-        + Storage<metadata::Data>
-        + psp34::extensions::metadata::PSP34Metadata
-        + psp34::Internal
-        + access_control::Internal,
+        + Storage<psp34::Data<enumerable::Balances>>,
 {
-    fn config(
-        &mut self,
-        name: String,
-        symbol: String,
-        base_uri: String,
-        max_supply: u64,
-        price_per_mint: Balance,
-        collection_metadata: String,
-    ) {
-        self._init_with_admin(<T as openbrush::traits::DefaultEnv>::env().caller());
-        self._setup_role(
-            CONTRIBUTOR,
-            <T as openbrush::traits::DefaultEnv>::env().caller(),
-        );
+    let minting: &mut rmrk_minting::MintingData = <T as StorageAsMut>::data(instance);
 
-        let psp34: &psp34::Data<enumerable::Balances> = <T as StorageAsRef>::data(self);
-        let collection_id = psp34.collection_id();
+    minting.price_per_mint = price_per_mint;
+}
 
-        self._set_attribute(collection_id.clone(), String::from("name"), name);
-        self._set_attribute(collection_id.clone(), String::from("symbol"), symbol);
-        self._set_attribute(collection_id.clone(), String::from("baseUri"), base_uri);
-        self._set_attribute(
-            collection_id,
-            String::from("collection_metadata"),
-            collection_metadata,
-        );
+pub fn with_admin<T>(instance: &mut T, account: AccountId)
+where
+    T: access_control::Internal + Storage<access_control::Data>,
+{
+    instance._init_with_admin(account);
+    instance._setup_role(CONTRIBUTOR, account);
+}
 
-        let minting: &mut rmrk_minting::MintingData = <T as StorageAsMut>::data(self);
-        minting.max_supply = max_supply;
-        minting.price_per_mint = price_per_mint;
-    }
+pub fn with_contributor<T>(instance: &mut T, account: AccountId)
+where
+    T: access_control::Internal + Storage<access_control::Data>,
+{
+    instance._setup_role(CONTRIBUTOR, account);
+}
 
-    fn config_with_royalties(
-        &mut self,
-        name: String,
-        symbol: String,
-        base_uri: String,
-        max_supply: u64,
-        price_per_mint: Balance,
-        collection_metadata: String,
-        _royalty_receiver: AccountId,
-        _royalty: u8,
-    ) {
-        Self::config(
-            self,
-            name,
-            symbol,
-            base_uri,
-            max_supply,
-            price_per_mint,
-            collection_metadata,
-        );
+pub fn with_parts<T>(instance: &mut T, parts: Vec<Part>) -> Result<(), PSP34Error>
+where
+    T: Storage<rmrk_base::BaseData> + Base,
+{
+    instance.add_part_list(parts)?;
+    Ok(())
+}
 
-        // Handle royalty inits here
-    }
+fn _with_royalties<T>(_instance: &mut T, _royalty_receiver: AccountId, _royalty: u8) {
+    todo!()
 }

--- a/crates/rmrk/src/lib.rs
+++ b/crates/rmrk/src/lib.rs
@@ -1,49 +1,27 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(feature = "mintable")]
-mod config;
+pub mod config;
+pub mod query;
 
-#[cfg(feature = "mintable")]
-pub use config::Config;
-
-pub mod roles {
-    pub use rmrk_common::roles::*;
-}
-
-pub mod errors {
-    pub use rmrk_common::errors::*;
-}
-
-pub mod types {
-    pub use rmrk_common::types::*;
-}
-
-pub mod utils {
-    pub use rmrk_common::utils::*;
-}
+pub use rmrk_common::{
+    errors,
+    roles,
+    types,
+    utils,
+};
 
 pub mod storage {
-    #[cfg(feature = "equippable")]
     pub use rmrk_base::*;
-    #[cfg(feature = "equippable")]
     pub use rmrk_equippable::*;
-    #[cfg(feature = "mintable")]
     pub use rmrk_minting::*;
-    #[cfg(feature = "equippable")]
     pub use rmrk_multiasset::*;
-    #[cfg(feature = "equippable")]
     pub use rmrk_nesting::*;
 }
 
 pub mod traits {
-    #[cfg(feature = "equippable")]
     pub use rmrk_base::traits::*;
-    #[cfg(feature = "equippable")]
     pub use rmrk_equippable::traits::*;
-    #[cfg(feature = "mintable")]
     pub use rmrk_minting::traits::*;
-    #[cfg(feature = "equippable")]
     pub use rmrk_multiasset::traits::*;
-    #[cfg(feature = "equippable")]
     pub use rmrk_nesting::traits::*;
 }

--- a/crates/rmrk/src/query.rs
+++ b/crates/rmrk/src/query.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::inline_fn_without_body)]
+
 use crate::traits::{
     BaseRef,
     MintingRef,

--- a/crates/rmrk/src/query.rs
+++ b/crates/rmrk/src/query.rs
@@ -1,0 +1,129 @@
+use crate::traits::{
+    BaseRef,
+    MintingRef,
+    MultiAssetRef,
+    NestingRef,
+};
+
+use ink_env::AccountId;
+use ink_prelude::vec::Vec;
+use ink_storage::traits::{
+    PackedLayout,
+    SpreadLayout,
+};
+use openbrush::{
+    contracts::psp34::extensions::enumerable::*,
+    traits::String,
+};
+use rmrk_common::{
+    errors::Error,
+    types::*,
+};
+
+#[derive(scale::Encode, scale::Decode, SpreadLayout, PackedLayout, Debug)]
+#[cfg_attr(
+    feature = "std",
+    derive(scale_info::TypeInfo, ink_storage::traits::StorageLayout)
+)]
+pub struct Token {
+    id: u64,
+    collection_id: CollectionId,
+    token_uri: String,
+    assets_pending: Vec<AssetId>,
+    assets_accepted: Vec<AssetId>,
+    children_pending: Vec<(AccountId, u64)>,
+    children_accepted: Vec<(AccountId, u64)>,
+}
+
+fn unsafe_id_to_u64(id: Id) -> u64 {
+    match id {
+        Id::U64(id) => id,
+        _ => panic!("Id not u64"),
+    }
+}
+
+fn unpack_children_id(children: Vec<(AccountId, Id)>) -> Vec<(AccountId, u64)> {
+    children
+        .into_iter()
+        .map(|(account_id, id)| (account_id, unsafe_id_to_u64(id)))
+        .collect()
+}
+
+fn nested_result_unwrap_or_default<T: Default>(res: Result<Result<T, Error>, ink_env::Error>) -> T {
+    match res {
+        Ok(Ok(v)) => v,
+        _ => Default::default(),
+    }
+}
+
+#[openbrush::wrapper]
+pub type QueryRef = dyn Query;
+
+#[openbrush::trait_definition]
+pub trait Query {
+    #[ink(message)]
+    fn get_part(&self, collection_id: AccountId, part_id: PartId) -> Option<Part> {
+        BaseRef::get_part_builder(&collection_id, part_id)
+            .fire()
+            .ok()
+            .flatten()
+    }
+
+    #[ink(message)]
+    fn get_asset(&self, collection_id: AccountId, asset_id: AssetId) -> Option<Asset> {
+        MultiAssetRef::get_asset_builder(&collection_id, asset_id)
+            .fire()
+            .ok()
+            .flatten()
+    }
+
+    #[ink(message)]
+    fn get_parts(&self, collection_id: AccountId, part_ids: Vec<PartId>) -> Vec<Part> {
+        part_ids
+            .into_iter()
+            .filter_map(|id| self.get_part(collection_id, id))
+            .collect()
+    }
+
+    #[ink(message)]
+    fn get_assets(&self, collection_id: AccountId, asset_ids: Vec<AssetId>) -> Vec<Asset> {
+        asset_ids
+            .into_iter()
+            .filter_map(|id| self.get_asset(collection_id, id))
+            .collect()
+    }
+
+    #[ink(message)]
+    fn get_token(&self, collection_id: AccountId, id_u64: u64) -> Token {
+        let id = Id::U64(id_u64);
+
+        let token_uri = MintingRef::token_uri(&collection_id, id_u64).unwrap_or_default();
+
+        let assets_pending = nested_result_unwrap_or_default(
+            MultiAssetRef::get_pending_token_assets_builder(&collection_id, id.clone()).fire(),
+        );
+
+        let assets_accepted = nested_result_unwrap_or_default(
+            MultiAssetRef::get_accepted_token_assets_builder(&collection_id, id.clone()).fire(),
+        );
+
+        let children_pending = NestingRef::get_pending_children_builder(&collection_id, id.clone())
+            .fire()
+            .unwrap_or_default();
+
+        let children_accepted =
+            NestingRef::get_accepted_children_builder(&collection_id, id.clone())
+                .fire()
+                .unwrap_or_default();
+
+        Token {
+            id: id_u64,
+            collection_id,
+            token_uri: String::from(token_uri),
+            assets_pending,
+            assets_accepted,
+            children_pending: unpack_children_id(children_pending),
+            children_accepted: unpack_children_id(children_accepted),
+        }
+    }
+}

--- a/examples/equippable-lazy/Cargo.toml
+++ b/examples/equippable-lazy/Cargo.toml
@@ -16,7 +16,7 @@ scale = { package = "parity-scale-codec", version = "3", default-features = fals
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 
 openbrush = { tag = "v2.3.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["ownable", "psp34", "reentrancy_guard"] }
-rmrk = { path = "../../crates/rmrk", default-features = false, features = ["equippable"] }
+rmrk = { path = "../../crates/rmrk", default-features = false  }
 
 
 [lib]

--- a/examples/equippable-lazy/lib.rs
+++ b/examples/equippable-lazy/lib.rs
@@ -25,10 +25,10 @@ pub mod rmrk_example_equippable {
     };
 
     use rmrk::{
+        config,
         storage::*,
         traits::*,
         types::*,
-        Config as RmrkConfig,
     };
 
     /// Event emitted when a token transfer occurs.
@@ -244,15 +244,16 @@ pub mod rmrk_example_equippable {
             _royalty: u8,
         ) -> Self {
             ink_lang::codegen::initialize_contract(|instance: &mut Rmrk| {
-                RmrkConfig::config(
+                config::with_admin(instance, Self::env().caller());
+                config::with_lazy_mint(instance, price_per_mint);
+                config::with_collection(
                     instance,
                     name,
                     symbol,
                     base_uri,
-                    max_supply,
-                    price_per_mint,
                     collection_metadata,
-                )
+                    max_supply,
+                );
             })
         }
     }

--- a/examples/equippable-lazy/lib.rs
+++ b/examples/equippable-lazy/lib.rs
@@ -26,6 +26,7 @@ pub mod rmrk_example_equippable {
 
     use rmrk::{
         config,
+        query::*,
         storage::*,
         traits::*,
         types::*,
@@ -228,6 +229,8 @@ pub mod rmrk_example_equippable {
     impl Base for Rmrk {}
 
     impl Equippable for Rmrk {}
+
+    impl Query for Rmrk {}
 
     impl Rmrk {
         /// Instantiate new RMRK contract

--- a/examples/equippable/Cargo.toml
+++ b/examples/equippable/Cargo.toml
@@ -16,7 +16,7 @@ scale = { package = "parity-scale-codec", version = "3", default-features = fals
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 
 openbrush = { tag = "v2.3.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["access_control", "psp34", "reentrancy_guard"] }
-rmrk = { path = "../../crates/rmrk", default-features = false, features = ["equippable"] }
+rmrk = { path = "../../crates/rmrk", default-features = false  }
 
 
 [lib]

--- a/examples/equippable/lib.rs
+++ b/examples/equippable/lib.rs
@@ -26,6 +26,7 @@ pub mod rmrk_example_equippable {
 
     use rmrk::{
         config,
+        query::*,
         storage::*,
         traits::*,
         types::*,
@@ -228,6 +229,8 @@ pub mod rmrk_example_equippable {
     impl Base for Rmrk {}
 
     impl Equippable for Rmrk {}
+
+    impl Query for Rmrk {}
 
     impl Rmrk {
         /// Instantiate new RMRK contract

--- a/examples/mintable/Cargo.toml
+++ b/examples/mintable/Cargo.toml
@@ -16,7 +16,7 @@ scale = { package = "parity-scale-codec", version = "3", default-features = fals
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 
 openbrush = { tag = "v2.3.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["access_control", "psp34", "reentrancy_guard"] }
-rmrk = { path = "../../crates/rmrk", default-features = false, features = ["mintable"] }
+rmrk = { path = "../../crates/rmrk", default-features = false  }
 
 
 [lib]

--- a/examples/mintable/lib.rs
+++ b/examples/mintable/lib.rs
@@ -26,6 +26,7 @@ pub mod rmrk_example_mintable {
 
     use rmrk::{
         config,
+        query::*,
         storage::*,
         traits::*,
     };
@@ -78,6 +79,8 @@ pub mod rmrk_example_mintable {
     impl PSP34Enumerable for Rmrk {}
 
     impl Minting for Rmrk {}
+
+    impl Query for Rmrk {}
 
     impl Rmrk {
         /// Instantiate new RMRK contract

--- a/examples/mintable/lib.rs
+++ b/examples/mintable/lib.rs
@@ -25,9 +25,9 @@ pub mod rmrk_example_mintable {
     };
 
     use rmrk::{
+        config,
         storage::*,
         traits::*,
-        Config as RmrkConfig,
     };
 
     /// Event emitted when a token transfer occurs.
@@ -88,20 +88,17 @@ pub mod rmrk_example_mintable {
             symbol: String,
             base_uri: String,
             max_supply: u64,
-            price_per_mint: Balance,
             collection_metadata: String,
-            _royalty_receiver: AccountId,
-            _royalty: u8,
         ) -> Self {
             ink_lang::codegen::initialize_contract(|instance: &mut Rmrk| {
-                RmrkConfig::config(
+                config::with_admin(instance, Self::env().caller());
+                config::with_collection(
                     instance,
                     name,
                     symbol,
                     base_uri,
-                    max_supply,
-                    price_per_mint,
                     collection_metadata,
+                    max_supply,
                 )
             })
         }

--- a/tests/base.spec.ts
+++ b/tests/base.spec.ts
@@ -101,14 +101,14 @@ describe("RMRK Base tests", () => {
         partType: PartType.slot,
         z: 0,
         equippable: [],
-        metadataUri: ["ipfs://backgrounds/1.svg"],
+        partUri: ["ipfs://backgrounds/1.svg"],
         isEquippableByAll: true,
       },
       {
         partType: PartType.fixed,
         z: 0,
         equippable: [],
-        metadataUri: ["ipfs://backgrounds/2.svg"],
+        partUri: ["ipfs://backgrounds/2.svg"],
         isEquippableByAll: false,
       },
     ];

--- a/tests/merged_equippable.spec.ts
+++ b/tests/merged_equippable.spec.ts
@@ -110,7 +110,7 @@ describe("RMRK Merged Equippable", () => {
         partType: PartType.fixed,
         z: 0,
         equippable: [],
-        metadataUri: ["ipfs://backgrounds/1.svg"],
+        partUri: ["ipfs://backgrounds/1.svg"],
         isEquippableByAll: false,
       },
       // Background option 2
@@ -118,7 +118,7 @@ describe("RMRK Merged Equippable", () => {
         partType: PartType.fixed,
         z: 0,
         equippable: [],
-        metadataUri: ["ipfs://backgrounds/2.svg"],
+        partUri: ["ipfs://backgrounds/2.svg"],
         isEquippableByAll: false,
       },
       // Head option 1
@@ -126,7 +126,7 @@ describe("RMRK Merged Equippable", () => {
         partType: PartType.fixed,
         z: 3,
         equippable: [],
-        metadataUri: ["ipfs://heads/1.svg"],
+        partUri: ["ipfs://heads/1.svg"],
         isEquippableByAll: false,
       },
       // Head option 2
@@ -134,7 +134,7 @@ describe("RMRK Merged Equippable", () => {
         partType: PartType.fixed,
         z: 3,
         equippable: [],
-        metadataUri: ["ipfs://heads/2.svg"],
+        partUri: ["ipfs://heads/2.svg"],
         isEquippableByAll: false,
       },
       // Body option 1
@@ -142,7 +142,7 @@ describe("RMRK Merged Equippable", () => {
         partType: PartType.fixed,
         z: 2,
         equippable: [],
-        metadataUri: ["ipfs://body/1.svg"],
+        partUri: ["ipfs://body/1.svg"],
         isEquippableByAll: false,
       },
       // Body option 2
@@ -150,7 +150,7 @@ describe("RMRK Merged Equippable", () => {
         partType: PartType.fixed,
         z: 2,
         equippable: [],
-        metadataUri: ["ipfs://body/2.svg"],
+        partUri: ["ipfs://body/2.svg"],
         isEquippableByAll: false,
       },
       // Wings option 1
@@ -158,7 +158,7 @@ describe("RMRK Merged Equippable", () => {
         partType: PartType.fixed,
         z: 1,
         equippable: [],
-        metadataUri: ["ipfs://wings/1.svg"],
+        partUri: ["ipfs://wings/1.svg"],
         isEquippableByAll: false,
       },
       // Wings option 2
@@ -166,7 +166,7 @@ describe("RMRK Merged Equippable", () => {
         partType: PartType.fixed,
         z: 1,
         equippable: [],
-        metadataUri: ["ipfs://wings/2.svg"],
+        partUri: ["ipfs://wings/2.svg"],
         isEquippableByAll: false,
       },
       // Gem slot 1
@@ -174,7 +174,7 @@ describe("RMRK Merged Equippable", () => {
         partType: PartType.slot,
         z: 4,
         equippable: [gem.address],
-        metadataUri: [""],
+        partUri: [""],
         isEquippableByAll: false,
       },
       // Gem slot 2
@@ -182,7 +182,7 @@ describe("RMRK Merged Equippable", () => {
         partType: PartType.slot,
         z: 4,
         equippable: [gem.address],
-        metadataUri: [""],
+        partUri: [""],
         isEquippableByAll: false,
       },
       // Gem slot 3
@@ -190,7 +190,7 @@ describe("RMRK Merged Equippable", () => {
         partType: PartType.slot,
         z: 4,
         equippable: [gem.address],
-        metadataUri: [""],
+        partUri: [""],
         isEquippableByAll: false,
       },
     ];


### PR DESCRIPTION
This PR contains a handful of updates/changes:

- Make metadata field naming convention consistent `base_uri, part_uri`

- Refactor `rmrk::config::Config` to allow better composition. Split `Config` trait into individual functions with relevant trait bounds.

- Remove cargo flags `mintable, equippable` as they were actually redundant. Compiled wasm contract size is the same with/without them - the only difference is in the rmrk crate dependency size at build-time. It might be better to reserve these flags for future configurable backends (psp34, uniques, etc) where conditional compilation may be required.

- Add `rmrk::query::Query` trait, for ui-based helpers. Tried a few different approaches but ran into various limitations - this feels the most versatile for now. Fetching children directly would lead to gas-limits quickly being hit, hence the `Token` type containing IDs. Not 100% satisfied with having two fields (pending & accepted) for assets/children, however this was the cleanest way to avoid introducing new duplicate types. The reason some functions are cross-contract builders is due to the impl potentially not existing on a child contract, so need to be able to directly handle the error otherwise the call will trap. Currently no tests for these, as it'll be much easier with e2e tests once we update to ink 4.0.

- Add getter methods required for Query functions `get_asset, get_pending_token_assets, get_pending_children, get_accepted_children`

