### PR TITLE
Update yarn compile with nightly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,14 +28,6 @@ jobs:
       - name: Check targets are installed correctly
         run: rustup target list --installed
 
-      - name: Cache Cargo
-        uses: actions/cache@v3
-        with:
-          path: ~/.cargo
-          key: ${{ runner.os }}-rust-${{ hashFiles('rust-toolchain.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-rust
-
       - name: Cargo check
         run: cargo +nightly check
 
@@ -46,12 +38,6 @@ jobs:
     needs: install
     runs-on: ubuntu-latest
     steps:
-      - name: Use cashed cargo
-        uses: actions/cache@v3
-        with:
-          path: ~/.cargo
-          key: ${{ runner.os }}-rust-${{ hashFiles('rust-toolchain.toml') }}
-
       - name: Checkout the source code
         uses: actions/checkout@v3
 
@@ -103,14 +89,6 @@ jobs:
 
     - name: Check targets are installed correctly
       run: rustup target list --installed
-
-    - name: Cache Crates
-      uses: actions/cache@v3
-      with:
-        path: ~/.cargo 
-        key: ${{ runner.os }}-rust-${{ hashFiles('rust-toolchain.toml') }}
-        restore-keys: |
-          ${{ runner.os }}-rust
 
     - name: Use Node.js
       uses: actions/setup-node@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,137 +1,201 @@
-name: Test
-
+name: PR checks
 on:
-  pull_request:
-    branches:
-      - main
   push:
-
+  workflow_dispatch:
 env:
   NODE_JS_VER: 18.x
   SWANKY_NODE_VER: v1.2.0
-  CONTRACTS_NODE: ./swanky-node
 jobs:
-  install:
+  tests:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout the source code
-        uses: actions/checkout@v3
+    - name: Checkout the source code
+      uses: actions/checkout@v3
 
-      - name: Install & display rust toolchain
-        run: |
-          rustup show
-          rustup toolchain install nightly
-          rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
-          rustup component add clippy --toolchain nightly-x86_64-unknown-linux-gnu
-          rustup show
+    - name: Install & display rust toolchain
+      run: |
+        rustup show
+        rustup component add rust-src
 
-      - name: Check targets are installed correctly
-        run: rustup target list --installed
+    - name: Check targets are installed correctly
+      run: rustup target list --installed
 
-      - name: Cache Cargo
-        uses: actions/cache@v3
-        with:
-          path: ~/.cargo
-          key: ${{ runner.os }}-rust-${{ hashFiles('rust-toolchain.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-rust
+    - name: Cache Crates
+      uses: actions/cache@v3
+      with:
+        path: ~/.cargo 
+        key: ${{ runner.os }}-rust-${{ hashFiles('rust-toolchain.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-rust
 
-      - name: Cargo check
-        run: cargo +nightly check
+    - name: Use Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ env.NODE_JS_VER }}
 
-      - name: Check Clippy
-        run: cargo +nightly clippy
+    - name: Check if cargo-contract exists
+      id: check-cargo-contract
+      continue-on-error: true
+      run: cargo contract --version
 
-  unittest:
-    needs: install
-    runs-on: ubuntu-latest
-    steps:
-      - name: Use cashed cargo
-        uses: actions/cache@v3
-        with:
-          path: ~/.cargo
-          key: ${{ runner.os }}-rust-${{ hashFiles('rust-toolchain.toml') }}
+    - name: Install cargo contract
+      if: ${{ steps.check-cargo-contract.outcome == 'failure' }}
+      run: |
+        cargo install cargo-dylint dylint-link
+        cargo install --force --locked cargo-contract
 
-      - name: Checkout the source code
-        uses: actions/checkout@v3
+    - name: Compile contracts
+      run: |
+        yarn
+        yarn compile
 
-      - name: Unit test
-        run: cargo test
+    - name: unit test
+      run: cargo test
 
-  # ink-e2e:
-  #   needs: [install, unittest]
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Use cashed cargo
-  #       uses: actions/cache@v3
-  #       with:
-  #         path: ~/.cargo
-  #         key: ${{ runner.os }}-rust-${{ hashFiles('rust-toolchain.toml') }}
+    - name: integration test
+      run: |
+        sudo wget https://github.com/AstarNetwork/swanky-node/releases/download/${{ env.SWANKY_NODE_VER }}/swanky-node-${{ env.SWANKY_NODE_VER }}-ubuntu-x86_64.tar.gz
+        sudo tar -zxvf swanky-node-${{ env.SWANKY_NODE_VER }}-ubuntu-x86_64.tar.gz
+        sudo chmod +x swanky-node
+        ./swanky-node -lerror,runtime::contracts=debug &
+        sleep 10
+        yarn test
 
-  #     - name: Checkout the source code
-  #       uses: actions/checkout@v3
 
-  #     - name: Ink e2e test
-  #       run: cargo test --features e2e-tests
+# name: Test
 
-  format:
-    needs: install
-    runs-on: ubuntu-latest
-    steps:
-      - name: Use cashed cargo
-        uses: actions/cache@v3
-        with:
-          path: ~/.cargo
-          key: ${{ runner.os }}-rust-${{ hashFiles('rust-toolchain.toml') }}
+# on:
+#   pull_request:
+#     branches:
+#       - main
+#   push:
 
-      - name: Checkout the source code
-        uses: actions/checkout@v3
+# env:
+#   NODE_JS_VER: 18.x
+#   SWANKY_NODE_VER: v1.2.0
+#   CONTRACTS_NODE: ./swanky-node
+# jobs:
+#   install:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Checkout the source code
+#         uses: actions/checkout@v3
 
-      - name: Format rust code
-        run: cargo fmt --all
+#       - name: Install & display rust toolchain
+#         run: |
+#           rustup show
+#           rustup toolchain install nightly
+#           rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
+#           rustup component add clippy --toolchain nightly-x86_64-unknown-linux-gnu
+#           rustup show
 
-  integration:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install & display rust toolchain
-        run: |
-          rustup toolchain install nightly
-          rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
-          rustup show
+#       - name: Check targets are installed correctly
+#         run: rustup target list --installed
 
-      - name: Check targets are installed correctly
-        run: rustup target list --installed
+#       - name: Cache Cargo
+#         uses: actions/cache@v3
+#         with:
+#           path: ~/.cargo
+#           key: ${{ runner.os }}-rust-${{ hashFiles('rust-toolchain.toml') }}
+#           restore-keys: |
+#             ${{ runner.os }}-rust
 
-      - name: Checkout the source code
-        uses: actions/checkout@v3
+#       - name: Cargo check
+#         run: cargo +nightly check
 
-      - name: Check if cargo-contract exists
-        id: check-cargo-contract
-        continue-on-error: true
-        run: cargo contract --version
+#       - name: Check Clippy
+#         run: cargo +nightly clippy
 
-      - name: Install cargo contract
-        if: ${{ steps.check-cargo-contract.outcome == 'failure' }}
-        run: |
-          cargo install cargo-dylint dylint-link
-          cargo install --force --locked cargo-contract
-          cargo contract --version
+#   unittest:
+#     needs: install
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Use cashed cargo
+#         uses: actions/cache@v3
+#         with:
+#           path: ~/.cargo
+#           key: ${{ runner.os }}-rust-${{ hashFiles('rust-toolchain.toml') }}
 
-      - name: Use Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ env.NODE_JS_VER }}
+#       - name: Checkout the source code
+#         uses: actions/checkout@v3
 
-      - name: Compile contracts
-        run: |
-          yarn
-          yarn compile
+#       - name: Unit test
+#         run: cargo test
 
-      - name: Integration test on Swanky-node
-        run: |
-          sudo wget https://github.com/AstarNetwork/swanky-node/releases/download/${{ env.SWANKY_NODE_VER }}/swanky-node-${{ env.SWANKY_NODE_VER }}-ubuntu-x86_64.tar.gz
-          sudo tar -zxvf swanky-node-${{ env.SWANKY_NODE_VER }}-ubuntu-x86_64.tar.gz
-          sudo chmod +x swanky-node
-          ./swanky-node -lerror,runtime::contracts=debug &
-          sleep 10
-          yarn test
+#   # ink-e2e:
+#   #   needs: [install, unittest]
+#   #   runs-on: ubuntu-latest
+#   #   steps:
+#   #     - name: Use cashed cargo
+#   #       uses: actions/cache@v3
+#   #       with:
+#   #         path: ~/.cargo
+#   #         key: ${{ runner.os }}-rust-${{ hashFiles('rust-toolchain.toml') }}
+
+#   #     - name: Checkout the source code
+#   #       uses: actions/checkout@v3
+
+#   #     - name: Ink e2e test
+#   #       run: cargo test --features e2e-tests
+
+#   format:
+#     needs: install
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Use cashed cargo
+#         uses: actions/cache@v3
+#         with:
+#           path: ~/.cargo
+#           key: ${{ runner.os }}-rust-${{ hashFiles('rust-toolchain.toml') }}
+
+#       - name: Checkout the source code
+#         uses: actions/checkout@v3
+
+#       - name: Format rust code
+#         run: cargo fmt --all
+
+#   integration:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Install & display rust toolchain
+#         run: |
+#           rustup toolchain install nightly
+#           rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
+#           rustup show
+
+#       - name: Check targets are installed correctly
+#         run: rustup target list --installed
+
+#       - name: Checkout the source code
+#         uses: actions/checkout@v3
+
+#       - name: Check if cargo-contract exists
+#         id: check-cargo-contract
+#         continue-on-error: true
+#         run: cargo contract --version
+
+#       - name: Install cargo contract
+#         if: ${{ steps.check-cargo-contract.outcome == 'failure' }}
+#         run: |
+#           cargo install cargo-dylint dylint-link
+#           cargo install --force --locked cargo-contract
+#           cargo contract --version
+
+#       - name: Use Node.js
+#         uses: actions/setup-node@v3
+#         with:
+#           node-version: ${{ env.NODE_JS_VER }}
+
+#       - name: Compile contracts
+#         run: |
+#           yarn
+#           yarn compile
+
+#       - name: Integration test on Swanky-node
+#         run: |
+#           sudo wget https://github.com/AstarNetwork/swanky-node/releases/download/${{ env.SWANKY_NODE_VER }}/swanky-node-${{ env.SWANKY_NODE_VER }}-ubuntu-x86_64.tar.gz
+#           sudo tar -zxvf swanky-node-${{ env.SWANKY_NODE_VER }}-ubuntu-x86_64.tar.gz
+#           sudo chmod +x swanky-node
+#           ./swanky-node -lerror,runtime::contracts=debug &
+#           sleep 10
+#           yarn test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,7 @@ on:
     branches:
       - main
   push:
-    branches:
-      - main
+
 env:
   NODE_JS_VER: 18.x
   SWANKY_NODE_VER: v1.2.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,96 @@
-name: PR checks
+name: RMRK Test
+
 on:
+  pull_request:
+    branches:
+      - main
   push:
-  workflow_dispatch:
+
 env:
   NODE_JS_VER: 18.x
   SWANKY_NODE_VER: v1.2.0
+  CONTRACTS_NODE: ./swanky-node
 jobs:
-  tests:
+  install:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the source code
+        uses: actions/checkout@v3
+
+      - name: Install & display rust toolchain
+        run: |
+          rustup show
+          rustup toolchain install nightly
+          rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
+          rustup component add clippy --toolchain nightly-x86_64-unknown-linux-gnu
+          rustup show
+
+      - name: Check targets are installed correctly
+        run: rustup target list --installed
+
+      - name: Cache Cargo
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-rust-${{ hashFiles('rust-toolchain.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-rust
+
+      - name: Cargo check
+        run: cargo +nightly check
+
+      - name: Check Clippy
+        run: cargo +nightly clippy
+
+  unittest:
+    needs: install
+    runs-on: ubuntu-latest
+    steps:
+      - name: Use cashed cargo
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-rust-${{ hashFiles('rust-toolchain.toml') }}
+
+      - name: Checkout the source code
+        uses: actions/checkout@v3
+
+      - name: Unit test
+        run: cargo test
+
+#   # ink-e2e:
+#   #   needs: [install, unittest]
+#   #   runs-on: ubuntu-latest
+#   #   steps:
+#   #     - name: Use cashed cargo
+#   #       uses: actions/cache@v3
+#   #       with:
+#   #         path: ~/.cargo
+#   #         key: ${{ runner.os }}-rust-${{ hashFiles('rust-toolchain.toml') }}
+
+#   #     - name: Checkout the source code
+#   #       uses: actions/checkout@v3
+
+#   #     - name: Ink e2e test
+#   #       run: cargo test --features e2e-tests
+
+  format:
+    needs: install
+    runs-on: ubuntu-latest
+    steps:
+      - name: Use cashed cargo
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-rust-${{ hashFiles('rust-toolchain.toml') }}
+
+      - name: Checkout the source code
+        uses: actions/checkout@v3
+
+      - name: Format rust code
+        run: cargo fmt --all
+
+  integration:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the source code
@@ -49,9 +133,6 @@ jobs:
         yarn
         yarn compile
 
-    - name: unit test
-      run: cargo test
-
     - name: integration test
       run: |
         sudo wget https://github.com/AstarNetwork/swanky-node/releases/download/${{ env.SWANKY_NODE_VER }}/swanky-node-${{ env.SWANKY_NODE_VER }}-ubuntu-x86_64.tar.gz
@@ -60,142 +141,3 @@ jobs:
         ./swanky-node -lerror,runtime::contracts=debug &
         sleep 10
         yarn test
-
-
-# name: Test
-
-# on:
-#   pull_request:
-#     branches:
-#       - main
-#   push:
-
-# env:
-#   NODE_JS_VER: 18.x
-#   SWANKY_NODE_VER: v1.2.0
-#   CONTRACTS_NODE: ./swanky-node
-# jobs:
-#   install:
-#     runs-on: ubuntu-latest
-#     steps:
-#       - name: Checkout the source code
-#         uses: actions/checkout@v3
-
-#       - name: Install & display rust toolchain
-#         run: |
-#           rustup show
-#           rustup toolchain install nightly
-#           rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
-#           rustup component add clippy --toolchain nightly-x86_64-unknown-linux-gnu
-#           rustup show
-
-#       - name: Check targets are installed correctly
-#         run: rustup target list --installed
-
-#       - name: Cache Cargo
-#         uses: actions/cache@v3
-#         with:
-#           path: ~/.cargo
-#           key: ${{ runner.os }}-rust-${{ hashFiles('rust-toolchain.toml') }}
-#           restore-keys: |
-#             ${{ runner.os }}-rust
-
-#       - name: Cargo check
-#         run: cargo +nightly check
-
-#       - name: Check Clippy
-#         run: cargo +nightly clippy
-
-#   unittest:
-#     needs: install
-#     runs-on: ubuntu-latest
-#     steps:
-#       - name: Use cashed cargo
-#         uses: actions/cache@v3
-#         with:
-#           path: ~/.cargo
-#           key: ${{ runner.os }}-rust-${{ hashFiles('rust-toolchain.toml') }}
-
-#       - name: Checkout the source code
-#         uses: actions/checkout@v3
-
-#       - name: Unit test
-#         run: cargo test
-
-#   # ink-e2e:
-#   #   needs: [install, unittest]
-#   #   runs-on: ubuntu-latest
-#   #   steps:
-#   #     - name: Use cashed cargo
-#   #       uses: actions/cache@v3
-#   #       with:
-#   #         path: ~/.cargo
-#   #         key: ${{ runner.os }}-rust-${{ hashFiles('rust-toolchain.toml') }}
-
-#   #     - name: Checkout the source code
-#   #       uses: actions/checkout@v3
-
-#   #     - name: Ink e2e test
-#   #       run: cargo test --features e2e-tests
-
-#   format:
-#     needs: install
-#     runs-on: ubuntu-latest
-#     steps:
-#       - name: Use cashed cargo
-#         uses: actions/cache@v3
-#         with:
-#           path: ~/.cargo
-#           key: ${{ runner.os }}-rust-${{ hashFiles('rust-toolchain.toml') }}
-
-#       - name: Checkout the source code
-#         uses: actions/checkout@v3
-
-#       - name: Format rust code
-#         run: cargo fmt --all
-
-#   integration:
-#     runs-on: ubuntu-latest
-#     steps:
-#       - name: Install & display rust toolchain
-#         run: |
-#           rustup toolchain install nightly
-#           rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
-#           rustup show
-
-#       - name: Check targets are installed correctly
-#         run: rustup target list --installed
-
-#       - name: Checkout the source code
-#         uses: actions/checkout@v3
-
-#       - name: Check if cargo-contract exists
-#         id: check-cargo-contract
-#         continue-on-error: true
-#         run: cargo contract --version
-
-#       - name: Install cargo contract
-#         if: ${{ steps.check-cargo-contract.outcome == 'failure' }}
-#         run: |
-#           cargo install cargo-dylint dylint-link
-#           cargo install --force --locked cargo-contract
-#           cargo contract --version
-
-#       - name: Use Node.js
-#         uses: actions/setup-node@v3
-#         with:
-#           node-version: ${{ env.NODE_JS_VER }}
-
-#       - name: Compile contracts
-#         run: |
-#           yarn
-#           yarn compile
-
-#       - name: Integration test on Swanky-node
-#         run: |
-#           sudo wget https://github.com/AstarNetwork/swanky-node/releases/download/${{ env.SWANKY_NODE_VER }}/swanky-node-${{ env.SWANKY_NODE_VER }}-ubuntu-x86_64.tar.gz
-#           sudo tar -zxvf swanky-node-${{ env.SWANKY_NODE_VER }}-ubuntu-x86_64.tar.gz
-#           sudo chmod +x swanky-node
-#           ./swanky-node -lerror,runtime::contracts=debug &
-#           sleep 10
-#           yarn test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   push:
+    branches:
+      - main
 
 env:
   NODE_JS_VER: 18.x

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "rmrm-project",
-  "version": "0.7.0",
+  "name": "rmrk-project",
+  "version": "0.6.0",
   "private": true,
   "dependencies": {
     "@727-ventures/typechain-compiler": "0.5.18",
@@ -24,7 +24,8 @@
     "node": ">=18.0.0"
   },
   "scripts": {
-    "compile": "typechain-compiler --release",
+    "compile": "typechain-compiler --toolchain nightly-2023-01-10",
+    "compile:release": "typechain-compiler --release --toolchain nightly-2023-01-10",
     "test": "mocha --require ts-node/register --recursive ./tests --extension \".spec.ts\" --exit --timeout 2000000",
     "test:single": "mocha --require ts-node/register --extension \".ts\" --exit --timeout 20000",
     "postinstall": "patch-package"
@@ -34,3 +35,4 @@
     "@polkadot/api-contract": "9.13.4"
   }
 }
+


### PR DESCRIPTION
Fixes failing integration test in Github action.

The `yarn compile` is not using nightly.
Update package.json scripts to run nightly