### PR TITLE
Catalog updates

### DIFF
--- a/crates/catalog/Cargo.toml
+++ b/crates/catalog/Cargo.toml
@@ -9,7 +9,6 @@ ink = { version = "4.1.0", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 openbrush = { tag = "3.1.0", git = "https://github.com/727-Ventures/openbrush-contracts", default-features = false, features = ["access_control", "reentrancy_guard", "psp34"] }
-
 rmrk_common = { path = "../common", default-features = false }
 
 [lib]

--- a/crates/catalog/src/catalog.rs
+++ b/crates/catalog/src/catalog.rs
@@ -114,7 +114,7 @@ where
 
     /// Sets the metadata URI for Catalog
     #[modifiers(only_role(CONTRIBUTOR))]
-    default fn setup_catalog(&mut self, catalog_metadata: String) -> Result<()> {
+    default fn set_catalog_metadata(&mut self, catalog_metadata: String) -> Result<()> {
         self.data::<CatalogData>().catalog_metadata = catalog_metadata;
 
         Ok(())

--- a/crates/catalog/src/catalog.rs
+++ b/crates/catalog/src/catalog.rs
@@ -121,11 +121,9 @@ where
     }
 
     /// Get the Catalog metadataURI.
-    default fn get_catalog_metadata(&self) -> PreludeString {
-        match PreludeString::from_utf8(self.data::<CatalogData>().catalog_metadata.clone()) {
-            Ok(m) => m,
-            _ => PreludeString::from(""),
-        }
+    default fn get_catalog_metadata(&self) -> Result<PreludeString> {
+        PreludeString::from_utf8(self.data::<CatalogData>().catalog_metadata.clone())
+            .map_err(|_| RmrkError::UriNotFound.into())
     }
 
     /// Get the number of parts.

--- a/crates/catalog/src/lib.rs
+++ b/crates/catalog/src/lib.rs
@@ -2,13 +2,10 @@
 #![feature(min_specialization)]
 #![allow(clippy::inline_fn_without_body)]
 
-pub use rmrk_common::{
-    errors,
-    roles,
-    types,
-    utils,
-};
-
 pub mod catalog;
 pub mod internal;
 pub mod traits;
+
+pub use catalog::*;
+pub use internal::*;
+pub use traits::*;

--- a/crates/catalog/src/traits.rs
+++ b/crates/catalog/src/traits.rs
@@ -42,7 +42,7 @@ pub trait Catalog {
 
     //// Set the Catalog metadataURI.
     #[ink(message)]
-    fn setup_catalog(&mut self, catalog_metadata: String) -> Result<()>;
+    fn set_catalog_metadata(&mut self, catalog_metadata: String) -> Result<()>;
 
     //// Get the Catalog metadataURI.
     #[ink(message)]

--- a/crates/catalog/src/traits.rs
+++ b/crates/catalog/src/traits.rs
@@ -46,7 +46,7 @@ pub trait Catalog {
 
     //// Get the Catalog metadataURI.
     #[ink(message)]
-    fn get_catalog_metadata(&self) -> PreludeString;
+    fn get_catalog_metadata(&self) -> Result<PreludeString>;
 
     /// Get the list of all parts.
     #[ink(message)]

--- a/crates/rmrk/Cargo.toml
+++ b/crates/rmrk/Cargo.toml
@@ -15,9 +15,7 @@ rmrk_multiasset = { path = "../multiasset", default-features = false }
 rmrk_nesting = { path = "../nesting", default-features = false }
 rmrk_common = { path = "../common", default-features = false }
 rmrk_equippable = { path = "../equippable", default-features = false }
-
-# external contracts
-rmrk_catalog = { path = "../catalog", default-features = false, features = ["ink-as-dependency"]}
+rmrk_catalog = { path = "../catalog", default-features = false }
 
 [lib]
 path = "src/lib.rs"

--- a/crates/rmrk/src/lib.rs
+++ b/crates/rmrk/src/lib.rs
@@ -15,6 +15,7 @@ pub mod storage {
     pub use rmrk_minting::*;
     pub use rmrk_multiasset::*;
     pub use rmrk_nesting::*;
+    pub use rmrk_catalog::*;
 }
 
 pub mod traits {
@@ -22,4 +23,5 @@ pub mod traits {
     pub use rmrk_minting::traits::*;
     pub use rmrk_multiasset::traits::*;
     pub use rmrk_nesting::traits::*;
+    pub use rmrk_catalog::traits::*;
 }

--- a/examples/catalog/Cargo.toml
+++ b/examples/catalog/Cargo.toml
@@ -9,9 +9,7 @@ ink = { version = "4.1.0", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 openbrush = { tag = "3.1.0", git = "https://github.com/727-Ventures/openbrush-contracts", default-features = false, features = ["access_control", "reentrancy_guard", "psp34"] }
-
-# RMRK
-rmrk_catalog = { path = "../../crates/catalog", default-features = false  }
+rmrk = { path = "../../crates/rmrk", default-features = false  }
 
 [lib]
 path = "lib.rs"
@@ -27,6 +25,6 @@ std = [
     "scale/std",
     "scale-info/std",
     "openbrush/std",
-    "rmrk_catalog/std",
+    "rmrk/std",
 ]
 ink-as-dependency = []

--- a/examples/catalog/lib.rs
+++ b/examples/catalog/lib.rs
@@ -11,10 +11,9 @@ pub mod catalog_example {
         },
     };
 
-    use rmrk_catalog::{
-        catalog::*,
+    use rmrk::{
         roles::*,
-        traits::*,
+        storage::*,
     };
 
     // CatalogContract contract storage
@@ -49,13 +48,12 @@ pub mod catalog_example {
 
         use ink::env::test;
 
-        use openbrush::contracts::psp34::extensions::enumerable::*;
-        use rmrk_catalog::{
+        use rmrk::{
             errors::*,
-            roles::ADMIN,
-            traits::Catalog,
             types::*,
         };
+
+        // use openbrush::contracts::psp34::extensions::enumerable::*;
 
         const METADATA: &str = "ipfs://myIpfsUri/";
         const EQUIPPABLE_ADDRESS1: [u8; 32] = [1; 32];
@@ -75,10 +73,10 @@ pub mod catalog_example {
 
         #[ink::test]
         fn add_parts_to_catalog_works() {
-            const ASSET_URI: &str = "asset_uri/";
-            const ASSET_ID: AssetId = 1;
-            const TOKEN_ID1: Id = Id::U64(1);
-            const TOKEN_ID2: Id = Id::U64(2);
+            // const ASSET_URI: &str = "asset_uri/";
+            // const ASSET_ID: AssetId = 1;
+            // const TOKEN_ID1: Id = Id::U64(1);
+            // const TOKEN_ID2: Id = Id::U64(2);
             const PART_ID0: PartId = 0;
             const PART_ID1: PartId = 1;
 

--- a/examples/catalog/lib.rs
+++ b/examples/catalog/lib.rs
@@ -12,6 +12,7 @@ pub mod catalog_example {
     };
 
     use rmrk::{
+        errors::Result,
         roles::*,
         storage::*,
     };
@@ -31,14 +32,14 @@ pub mod catalog_example {
     impl CatalogContract {
         /// Instantiate new CatalogContract contract
         #[ink(constructor)]
-        pub fn new(catalog_metadata: String) -> Self {
+        pub fn new(catalog_metadata: String) -> Result<Self> {
             let mut instance = CatalogContract::default();
             let admin = Self::env().caller();
             instance._init_with_admin(admin);
             instance._setup_role(CONTRIBUTOR, admin);
-            _ = Catalog::setup_catalog(&mut instance, catalog_metadata);
+            Catalog::set_catalog_metadata(&mut instance, catalog_metadata)?;
 
-            instance
+            Ok(instance)
         }
     }
 
@@ -68,7 +69,7 @@ pub mod catalog_example {
         }
 
         fn init() -> CatalogContract {
-            CatalogContract::new(String::from(METADATA).into())
+            CatalogContract::new(String::from(METADATA).into()).expect("Contract instantiated")
         }
 
         #[ink::test]
@@ -202,7 +203,7 @@ pub mod catalog_example {
 
             assert_eq!(catalog.get_catalog_metadata(), Ok(METADATA.to_string()));
             assert!(catalog
-                .setup_catalog(String::from("ipfs://catalog_metadata2"))
+                .set_catalog_metadata(String::from("ipfs://catalog_metadata2"))
                 .is_ok());
             assert_eq!(
                 catalog.get_catalog_metadata(),

--- a/examples/catalog/lib.rs
+++ b/examples/catalog/lib.rs
@@ -200,11 +200,14 @@ pub mod catalog_example {
         fn setting_metadata_works() {
             let mut catalog = init();
 
-            assert_eq!(catalog.get_catalog_metadata(), METADATA);
+            assert_eq!(catalog.get_catalog_metadata(), Ok(METADATA.to_string()));
             assert!(catalog
                 .setup_catalog(String::from("ipfs://catalog_metadata2"))
                 .is_ok());
-            assert_eq!(catalog.get_catalog_metadata(), "ipfs://catalog_metadata2");
+            assert_eq!(
+                catalog.get_catalog_metadata(),
+                Ok("ipfs://catalog_metadata2".to_string())
+            );
         }
 
         fn default_accounts() -> test::DefaultAccounts<ink::env::DefaultEnvironment> {

--- a/examples/equippable-lazy/Cargo.toml
+++ b/examples/equippable-lazy/Cargo.toml
@@ -9,11 +9,7 @@ ink = { version = "4.1.0", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 openbrush = { tag = "3.1.0", git = "https://github.com/727-Ventures/openbrush-contracts", default-features = false, features = ["access_control", "reentrancy_guard", "psp34"] }
-
-# RMRK
 rmrk = { path = "../../crates/rmrk", default-features = false  }
-rmrk_catalog = { path = "../../crates/catalog", default-features = false  }
-
 
 [lib]
 path = "lib.rs"

--- a/examples/equippable/Cargo.toml
+++ b/examples/equippable/Cargo.toml
@@ -9,11 +9,7 @@ ink = { version = "4.1.0", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 openbrush = { tag = "3.1.0", git = "https://github.com/727-Ventures/openbrush-contracts", default-features = false, features = ["access_control", "reentrancy_guard", "psp34"] }
-
-# RMRK
 rmrk = { path = "../../crates/rmrk", default-features = false  }
-rmrk_catalog = { path = "../../crates/catalog", default-features = false  }
-
 
 
 [lib]

--- a/examples/mintable/Cargo.toml
+++ b/examples/mintable/Cargo.toml
@@ -9,8 +9,6 @@ ink = { version = "4.1.0", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 openbrush = { tag = "3.1.0", git = "https://github.com/727-Ventures/openbrush-contracts", default-features = false, features = ["access_control", "reentrancy_guard", "psp34"] }
-
-#RMRK
 rmrk = { path = "../../crates/rmrk", default-features = false  }
 
 [lib]


### PR DESCRIPTION
Currently it's not possible to access Catalog modules without manually depending on the `rmrk_catalog` crate. This breaks the current convention of the single `rmrk` crate entrypoint.

This PR exposes the catalog modules via the `rmrk` entrypoint crate, and updates the `catalog_example` dependencies.

Other fixes:
- Handle invalid utf8 metadata with `RmrkError` instead of empty string
- Fallible constructor in `catalog_example`