### PR TITLE
Add optional catalog field to Asset

### DIFF
--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -2,8 +2,8 @@
 #![feature(min_specialization)]
 #![allow(clippy::inline_fn_without_body)]
 
+pub mod counter;
 pub mod errors;
 pub mod roles;
 pub mod types;
 pub mod utils;
-pub mod counter;

--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -35,6 +35,9 @@ pub struct Asset {
 
     /// list of parts for this asset
     pub part_ids: Vec<PartId>,
+
+    /// The catalog to which the asset belongs to.
+    pub catalog: Option<AccountId>,
 }
 
 /// Part's details

--- a/crates/equippable/src/lib.rs
+++ b/crates/equippable/src/lib.rs
@@ -86,12 +86,7 @@ where
         )?;
 
         // Check from base perspective. If catalog for this asset is None, then it is not equippable.
-        match self
-            .data::<MultiAssetData>()
-            .asset_catalog_address
-            .get(asset_id)
-            .ok_or(RmrkError::CatalogNotFoundForAsset)?
-        {
+        match self.get_asset_catalog_address(asset_id) {
             Some(catalog_address) => {
                 CatalogRef::ensure_equippable(&catalog_address, slot_part_id, child_nft.0)?;
             }

--- a/crates/equippable/src/traits.rs
+++ b/crates/equippable/src/traits.rs
@@ -99,6 +99,7 @@ pub trait Equippable {
     /// # Returns:
     ///    * asset_id metadataURI,
     ///    * EquippableAsset
+    ///    * catalog address
     #[ink(message)]
     fn get_asset_and_equippable_data(&self, token_id: Id, asset_id: AssetId) -> Result<Asset>;
 

--- a/crates/minting/tests/core.rs
+++ b/crates/minting/tests/core.rs
@@ -239,10 +239,7 @@ pub mod rmrk_contract_minting {
             assert_eq!(2, ink::env::test::recorded_events().count());
 
             // token_uri for rmrk mint works
-            assert_eq!(
-                rmrk.token_uri(2),
-                Ok(RMRK_METADATA.to_owned())
-            );
+            assert_eq!(rmrk.token_uri(2), Ok(RMRK_METADATA.to_owned()));
         }
 
         #[ink::test]

--- a/crates/multiasset/src/lib.rs
+++ b/crates/multiasset/src/lib.rs
@@ -9,7 +9,6 @@ pub mod extensions {
     pub mod autoindex;
 }
 
-
 use internal::Internal;
 
 use rmrk_common::{
@@ -61,10 +60,6 @@ pub struct MultiAssetData {
 
     /// Mapping of tokenId to an array of pending assets
     pub pending_assets: Mapping<Id, Vec<AssetId>>,
-
-    /// Catalog assigned to assetId. Added with add_asset_entry
-    /// An asset can also have None as a catalog, hence the Option
-    pub asset_catalog_address: Mapping<AssetId, Option<AccountId>>,
 }
 
 impl<T> MultiAsset for T
@@ -93,14 +88,12 @@ where
                     equippable_group_id,
                     asset_uri,
                     part_ids: part_ids.clone(),
+                    catalog: catalog_address.clone(),
                 },
             );
         self.data::<MultiAssetData>()
             .collection_asset_ids
             .push(asset_id);
-        self.data::<MultiAssetData>()
-            .asset_catalog_address
-            .insert(asset_id, &catalog_address);
         self._emit_asset_set_event(&asset_id);
 
         Ok(())
@@ -278,10 +271,7 @@ where
 
     /// Fetch asset's catalog
     fn get_asset_catalog_address(&self, asset_id: AssetId) -> Option<AccountId> {
-        self.data::<MultiAssetData>()
-            .asset_catalog_address
-            .get(asset_id)
-            .unwrap_or_default()
+        self.get_asset(asset_id).unwrap_or_default().catalog
     }
 }
 

--- a/examples/catalog/lib.rs
+++ b/examples/catalog/lib.rs
@@ -261,7 +261,6 @@ pub mod catalog_example {
                 CatalogAutoIndex::add_part_list(&mut catalog, vec![]),
                 Err(RmrkError::BadConfig.into())
             );
-
         }
 
         #[ink::test]

--- a/tests/equip.spec.ts
+++ b/tests/equip.spec.ts
@@ -232,6 +232,9 @@ describe("RMRK Merged Equippable", () => {
         [4]
       );
     emit(addAssetResult, "AssetSet", { asset: 1 });
+    expect(
+      (await avatar.withSigner(deployer).query.getAssetAndEquippableData({ u64: 1 }, defaultAssetId))?.value.unwrap().ok.catalog
+    ).to.be.equal(catalog.address);
 
     console.log(" Added an asset to avatar");
 
@@ -283,6 +286,16 @@ describe("RMRK Merged Equippable", () => {
     expect(
       (await sword.withSigner(deployer).query.totalAssets())?.value.unwrap().toString()
     ).to.be.equal("3");
+
+    expect(
+      (await sword.withSigner(deployer).query.getAssetAndEquippableData({ u64: 1 }, equippableWoodenSword))?.value.unwrap().ok.catalog
+    ).to.be.equal(catalog.address);
+    expect(
+      (await sword.withSigner(deployer).query.getAssetAndEquippableData({ u64: 1 }, equippableCopperSword))?.value.unwrap().ok.catalog
+    ).to.be.equal(catalog.address);
+    expect(
+      (await sword.withSigner(deployer).query.getAssetAndEquippableData({ u64: 1 }, equippableKatanaSword))?.value.unwrap().ok.catalog
+    ).to.be.equal(catalog.address);
     console.log(" Added 3 sword assets");
 
     console.log("Setting valid parent reference ID");


### PR DESCRIPTION
As the title mentions this adds a new optional field to the existing `Asset` struct.
With this new field, the `asset_catalog_address` mapping is not needed anymore.

- [x]  Add integration test

Closes: #46