### PR TITLE
PSP34 `token_uri` metadata

### DIFF
--- a/crates/minting/src/internal.rs
+++ b/crates/minting/src/internal.rs
@@ -24,7 +24,7 @@ pub trait Internal {
     fn _check_amount(&self, mint_amount: u64) -> Result<()>;
 
     /// Get URI for the token Id.
-    fn _token_uri(&self, token_id: u64) -> Result<PreludeString>;
+    fn _token_uri(&self, token_id: Id) -> Result<PreludeString>;
 }
 
 /// Helper trait for Minting
@@ -71,10 +71,8 @@ where
     }
 
     /// Get URI for the token Id.
-    default fn _token_uri(&self, token_id: u64) -> Result<PreludeString> {
-        self.data::<MintingData>()
-            .nft_metadata
-            .get(Id::U64(token_id))
+    default fn _token_uri(&self, token_id: Id) -> Result<PreludeString> {
+        self.get_attribute(token_id, PreludeString::from("token_uri").into())
             .and_then(|token_uri| PreludeString::from_utf8(token_uri).ok())
             .ok_or(RmrkError::UriNotFound.into())
     }

--- a/crates/minting/src/lib.rs
+++ b/crates/minting/src/lib.rs
@@ -18,12 +18,9 @@ use rmrk_common::{
     utils::Utils,
 };
 
-use ink::{
-    prelude::{
-        string::String as PreludeString,
-        vec::Vec,
-    },
-    storage::Mapping,
+use ink::prelude::{
+    string::String as PreludeString,
+    vec::Vec,
 };
 
 use openbrush::{
@@ -59,7 +56,6 @@ pub const STORAGE_MINTING_KEY: u32 = openbrush::storage_unique_key!(MintingData)
 pub struct MintingData {
     pub max_supply: Option<u64>,
     pub price_per_mint: Balance,
-    pub nft_metadata: Mapping<Id, String>,
 }
 
 impl<T> Minting for T
@@ -94,9 +90,7 @@ where
     /// Assign metadata to specified token.
     #[modifiers(only_role(CONTRIBUTOR))]
     default fn assign_metadata(&mut self, token_id: Id, metadata: String) -> Result<()> {
-        self.data::<MintingData>()
-            .nft_metadata
-            .insert(token_id, &metadata);
+        self._set_attribute(token_id, String::from("token_uri"), metadata);
         Ok(())
     }
 
@@ -106,8 +100,8 @@ where
     }
 
     /// Get URI for the token Id.
-    default fn token_uri(&self, token_id: u64) -> Result<PreludeString> {
-        self.ensure_exists_and_get_owner(&Id::U64(token_id))?;
+    default fn token_uri(&self, token_id: Id) -> Result<PreludeString> {
+        self.ensure_exists_and_get_owner(&token_id)?;
         self._token_uri(token_id)
     }
 }
@@ -144,8 +138,8 @@ where
     }
 
     /// Get URI for the token Id.
-    default fn token_uri(&self, token_id: u64) -> Result<PreludeString> {
-        self.ensure_exists_and_get_owner(&Id::U64(token_id))?;
+    default fn token_uri(&self, token_id: Id) -> Result<PreludeString> {
+        self.ensure_exists_and_get_owner(&token_id)?;
         self._token_uri(token_id)
     }
 

--- a/crates/minting/src/traits.rs
+++ b/crates/minting/src/traits.rs
@@ -46,7 +46,7 @@ pub trait Minting {
 
     /// Get URI for the token Id.
     #[ink(message)]
-    fn token_uri(&self, token_id: u64) -> Result<PreludeString>;
+    fn token_uri(&self, token_id: Id) -> Result<PreludeString>;
 }
 
 /// Trait definitions for lazy Minting functions
@@ -70,7 +70,7 @@ pub trait MintingLazy {
 
     /// Get URI for the token Id.
     #[ink(message)]
-    fn token_uri(&self, token_id: u64) -> Result<PreludeString>;
+    fn token_uri(&self, token_id: Id) -> Result<PreludeString>;
 }
 
 /// Trait definitions for MintingAutoIndex functions

--- a/crates/minting/tests/core.rs
+++ b/crates/minting/tests/core.rs
@@ -240,7 +240,7 @@ pub mod rmrk_contract_minting {
 
             // token_uri for rmrk mint works
             assert_eq!(
-                rmrk.token_uri(2),
+                rmrk.token_uri(Id::U64(2)),
                 Ok(RMRK_METADATA.to_owned())
             );
         }
@@ -330,15 +330,15 @@ pub mod rmrk_contract_minting {
 
             assert!(rmrk.mint(accounts.alice, Id::U64(1)).is_ok());
             // return error if request is for not yet minted token
-            assert_eq!(rmrk.token_uri(42), Err(PSP34Error::TokenNotExists.into()));
+            assert_eq!(rmrk.token_uri(Id::U64(42)), Err(PSP34Error::TokenNotExists.into()));
             // return error if metadata is net yet assigned
-            assert_eq!(rmrk.token_uri(1), Err(RmrkError::UriNotFound.into()));
+            assert_eq!(rmrk.token_uri(Id::U64(1)), Err(RmrkError::UriNotFound.into()));
 
             assert!(rmrk
                 .assign_metadata(Id::U64(1), String::from(RMRK_METADATA))
                 .is_ok());
 
-            assert_eq!(rmrk.token_uri(1), Ok(PreludeString::from(RMRK_METADATA)));
+            assert_eq!(rmrk.token_uri(Id::U64(1)), Ok(PreludeString::from(RMRK_METADATA)));
         }
     }
 }

--- a/crates/rmrk/src/query.rs
+++ b/crates/rmrk/src/query.rs
@@ -77,15 +77,10 @@ pub trait Query: DefaultEnv {
 
     #[ink(message)]
     fn get_token(&self, id: Id) -> Token {
-        let id_u64 = match id {
-            Id::U64(id) => id.clone(),
-            _ => panic!("expecting Id::U64"),
-        };
-
         let collection_id = <Self as DefaultEnv>::env().account_id();
 
         let token_uri = nested_deep_result_unwrap_or_default(
-            MintingRef::token_uri_builder(&collection_id, id_u64)
+            MintingRef::token_uri_builder(&collection_id, id.clone())
                 .call_flags(ink::env::CallFlags::default().set_allow_reentry(true))
                 .try_invoke(),
         );


### PR DESCRIPTION
Currently we have our own `nft_metadata` storage which we use for assigning metadata to tokens. `PSP34Metadata` provides it's own solution for storing metadata (attributes), which we are using for collections but not tokens. 

This PR removes our custom `nft_metadata` storage, and instead uses the `PSP34Metedata` attribute implementation. The benefit here is we can access token metadata via the public ink `PSPS34Metadata_get_attribute` function, as well as the provided `token_uri()` function.

I have also fixed a discrepancy where `token_uri` was accepting a `u64` instead of an `Id` type.